### PR TITLE
Add filtered operators and initializer

### DIFF
--- a/eo/src/eoFilterMonOp.h
+++ b/eo/src/eoFilterMonOp.h
@@ -1,0 +1,75 @@
+/* Software License Agreement (GNU GPLv3)
+ *
+ * Copyright (C) 2013  Patrick Lehner <lehner.patrick@gmx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EO_FILTERMONOP_H
+#define EO_FILTERMONOP_H
+
+// C++ library includes
+#include <iostream>
+#include <vector>
+
+// EO library includes
+#include <eo> // eo general include
+#include <eoOp.h>
+
+template< class EOT >
+class eoFilterMonOp: public eoMonOp< EOT >
+{
+  public:
+    typedef bool(*FilterFuncPtr)(const EOT&);
+
+    eoFilterMonOp(eoMonOp<EOT>* actualOp_) :
+        eoMonOp< EOT >(), actualOp(actualOp_)
+    {}
+
+    virtual ~eoFilterMonOp() {}
+
+    bool operator()(EOT& _eo1) {
+        EOT eo2(_eo1);
+
+        if (!(*actualOp)(eo2))
+            return false;
+
+        bool accepted = true;
+        for (FilterFuncPtr fp : filters)
+            if ( !(*fp)(eo2) ) {
+                accepted = false;
+                break;
+            }
+
+        if (accepted) {
+            _eo1 = eo2;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool add(FilterFuncPtr fp) {
+        if (!fp)
+            return false;
+        filters.push_back(fp);
+        return true;
+    }
+
+  private:
+    eoMonOp<EOT>* actualOp;
+    std::vector<FilterFuncPtr> filters;
+};
+
+#endif // SOPARS_EO_FILTERMONOP_HPP

--- a/eo/src/eoFilterQuadOp.h
+++ b/eo/src/eoFilterQuadOp.h
@@ -1,0 +1,77 @@
+/* Software License Agreement (GNU GPLv3)
+ *
+ * Copyright (C) 2013  Patrick Lehner <lehner.patrick@gmx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EO_FILTERQUADOP_H
+#define EO_FILTERQUADOP_H
+
+// C++ library includes
+#include <iostream>
+#include <vector>
+
+// EO library includes
+#include <eo> // eo general include
+#include <eoOp.h>
+
+template< class EOT >
+class eoFilterQuadOp: public eoQuadOp< EOT >
+{
+  public:
+    typedef bool(*FilterFuncPtr)(const EOT&);
+
+    eoFilterQuadOp(eoQuadOp<EOT>* actualOp_) :
+        eoQuadOp< EOT >(), actualOp(actualOp_)
+    {}
+
+    virtual ~eoFilterQuadOp() {}
+
+    bool operator()(EOT& _eo1, EOT& _eo2) {
+        EOT cpeo1(_eo1);
+        EOT cpeo2(_eo2);
+
+        if (!(*actualOp)(cpeo1, cpeo2))
+            return false;
+
+        bool accepted = true;
+        for (FilterFuncPtr fp : filters)
+            if ( !(*fp)(cpeo1) || !(*fp)(cpeo2) ) {
+                accepted = false;
+                break;
+            }
+
+        if (accepted) {
+            _eo1 = cpeo1;
+            _eo2 = cpeo2;
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    bool add(FilterFuncPtr fp) {
+        if (!fp)
+            return false;
+        filters.push_back(fp);
+        return true;
+    }
+
+  private:
+    eoQuadOp<EOT>* actualOp;
+    std::vector<FilterFuncPtr> filters;
+};
+
+#endif // SOPARS_EO_FILTERQUADOP_HPP

--- a/eo/src/eoInitFilter.h
+++ b/eo/src/eoInitFilter.h
@@ -1,0 +1,75 @@
+/* Software License Agreement (GNU GPLv3)
+ *
+ * Copyright (C) 2013  Patrick Lehner <lehner.patrick@gmx.de>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EO_INITFILTER_H
+#define EO_INITFILTER_H
+
+// C++ library includes
+#include <iostream>
+#include <vector>
+
+// EO library includes
+#include <eo> // eo general include
+#include <eoInit.h>
+
+template<class EOT>
+class eoInitFilter : public eoInit<EOT> {
+
+  public:
+    typedef bool(*FilterFuncPtr)(const EOT&);
+
+    eoInitFilter(eoInit<EOT>* actualInit_) :
+        eoInit<EOT>(), actualInit(actualInit_)
+    {
+        if (!actualInit_)
+            std::cerr << "ERROR: No actual initializer given for eoInitFilter" << std::endl;
+    }
+
+    /// My class name
+    virtual std::string className() const { return "eoInteractiveInit"; };
+
+    void operator()(EOT& _eo)
+    {
+        bool accepted = false;
+
+        while (!accepted) {
+            (*actualInit)(_eo);
+
+            accepted = true;
+            for (FilterFuncPtr fp : filters)
+                if ( !(*fp)(_eo) ) {
+                    accepted = false;
+                    break;
+                }
+        }
+    }
+
+    bool add(FilterFuncPtr fp) {
+        if (!fp)
+            return false;
+        filters.push_back(fp);
+        return true;
+    }
+
+  private:
+    eoInit<EOT>* actualInit;
+    std::vector<FilterFuncPtr> filters;
+
+};
+
+#endif // SOPARS_EO_INITFILTER_HPP


### PR DESCRIPTION
These three classes are variants of the standard initializer (`eoInit`) and the main operators (`eoMonOp` and `eoQuadOp`) which filter the output individuals by a simple mechanism:
- create an instance `C`, which takes an object of its superclass to do the actual work
- add an arbitrary number of filter functions with the signature `bool function(EOT individual)`
- when `operator()` is called on `C`, 
  - the operators will call their underlying operator to create one or two new individuals, and then apply all filter functions; if any of them returns `false` ( _"not accepted"_ ), the created individual(s) is/are rejected and `operator()` will return `false` ( _"individual(s) unchanged"_ )
  - the initializer will call its underlying initializer to create one individual, and then apply all filter functions; if any of them returns `false` ( _"not accepted"_ ), it will use the underlying initializer to create a new individual; this is repeated until the individual is accepted

Some points to consider and discuss:
- would you like to have tests for these classes? if so, do you have any guidelines for unit tests? (I have no experience with tests myself, but i'm willing to actively contribute)
- I will add some Doxygen comments soon
- shall `eoInitFilter` be renamed to `eoFilterInit` (so all classes follow a common scheme) ?
- do you think an analogous class for `eoBinOp` should be created?
- the files are currently carrying a GPLv3 license notice, but I saw that most other files have GPLv2 instead; if you want to keep the whole project under v2, I can change the license for the files.
