### PR TITLE
Added 'continue' folder to moeo/src/CMakeLists.txt

### DIFF
--- a/moeo/src/CMakeLists.txt
+++ b/moeo/src/CMakeLists.txt
@@ -36,7 +36,7 @@ install(FILES ${HDRS} DESTINATION include${INSTALL_SUB_DIR}/moeo COMPONENT heade
 ### 4) Install directories
 ######################################################################################
 
-install(DIRECTORY acceptCrit algo archive comparator core distance diversity do explorer fitness hybridization metric replacement scalarStuffs selection utils
+install(DIRECTORY acceptCrit algo archive comparator continue core distance diversity do explorer fitness hybridization metric replacement scalarStuffs selection utils
         DESTINATION include${INSTALL_SUB_DIR}/moeo
         COMPONENT headers
         FILES_MATCHING PATTERN "*.h"


### PR DESCRIPTION
'continue' folder was previously missing from the installation list. Errors would occur when we call certain classes that require headers from 'continue' folder.

With this fix, the following 2 files will be installed when we perform 'make install' command:
- paradiseo/moeo/continue/moeoDualHypContinue.h
- paradiseo/moeo/continue/moeoHypContinue.h
