### PR TITLE
docs: add accelerator physics paper to publications list

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -998,6 +998,11 @@ undiscovered knowledge.
         <li>Johann Dreo, <a href="https://dl.acm.org/doi/10.1145/1570256.1570301">Using Performance Fronts for Parameter Setting of Stochastic Metaheuristics</a>, <i>Genetic and Evolutionary Computation Conference</i>, (2009).</li>
 </ul>
 
+<h3>Accelerator Physics</h3>
+<ul>
+    <li>E. Valetov, G. Dal Maso, P-R. Kettle, A. Knecht, A. Papa, on behalf of the HIMB Project. <a href="https://doi.org/10.3390/particles7030039">Beamline Optimisation for High-Intensity Muon Beams at PSI Using the Heterogeneous Island Model</a>. <i>Particles</i> <b>2024</b>, <i>7</i>, 683-691.</li>
+</ul>
+
     </div>
     </div>
 


### PR DESCRIPTION
This PR adds a new publication to the "Selection of publications using Paradiseo" section of documentation. The added paper reflects an application of Paradiseo in the field of Accelerator Physics, specifically for beamline optimisation.