### PR TITLE
Ccache setup

### DIFF
--- a/.github/workflows/build_ubuntu_debug.yml
+++ b/.github/workflows/build_ubuntu_debug.yml
@@ -16,8 +16,15 @@ jobs:
         compiler: [g++-10, g++-9, g++-8, g++-7, clang-6, clang-7, clang-8, clang-9, clang-10, clang-11, clang-12] 
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     
+    - name: Caching objects
+      id: cache-objects
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: ${{ runner.os }}-${{env.BUILD_TYPE}}-${{ matrix.compiler }}-objects
+
     - name: Install Dependencies
       shell: bash
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,17 @@ project("ParadisEO"
 ## Language
 set(CMAKE_CXX_STANDARD 17)
 
+## ccache
+find_program(CCACHE_PROGRAM ccache)
+
+if (CCACHE_PROGRAM)
+    message(NOTICE "-- ccache is enabled (found here: ${CCACHE_PROGRAM})")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "\"${CCACHE_PROGRAM}\"")
+    set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "\"${CCACHE_PROGRAM}\"")
+else ()
+    message(NOTICE "-- ccache has not been found")
+endif ()
+
 
 ######################################################################################
 ### 2) Check dependencies

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ If you `ENABLE_CMAKE_EXAMPLE`, it will also build the examples.
 If may want to make build scripts more verbose (especially when building the
 doc) by enabling `CMAKE_VERBOSE_MAKEFILE`.
 
+If `ccache` installed in your environment, library recompilation times can be significantly reduced. To clear all cached objects, execute `ccache -C`.
 
 ## Licenses
 


### PR DESCRIPTION
The goal is to speed up recompilation using ccache.

Ccache is a tool that speeds up recompilation of C/C++ code. It does this by caching the results of previous compilations. When you recompile code, ccache checks if it has already compiled the same code with the same compiler flags. If so, it uses the cached result instead of recompiling.