### PR TITLE
feat(moeo): add finalize() lifecycle hook for algorithm post-processing

### DIFF
--- a/moeo/src/algo/moeoAlgo.h
+++ b/moeo/src/algo/moeoAlgo.h
@@ -42,6 +42,12 @@
  * Abstract class for multi-objective algorithms.
  */
 class moeoAlgo
-  {};
+{
+public:
+    virtual ~moeoAlgo() = default;
+
+    /** Whether this algorithm supports finalize() for post-integration updates. */
+    virtual bool hasFinalize() const { return false; }
+};
 
 #endif /*MOEOALGO_H_*/

--- a/moeo/src/algo/moeoAlgoFinalized.h
+++ b/moeo/src/algo/moeoAlgoFinalized.h
@@ -1,9 +1,6 @@
 /*
-* <moeoAlgo.h>
-* Copyright (C) DOLPHIN Project-Team, INRIA Futurs, 2006-2007
-* (C) OPAC Team, LIFL, 2002-2007
-*
-* Arnaud Liefooghe
+* <moeoAlgoFinalized.h>
+* Copyright (C) Eremey Valetov, 2026
 *
 * This software is governed by the CeCILL license under French law and
 * abiding by the rules of distribution of free software.  You can  use,
@@ -29,22 +26,36 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------
 
-#ifndef MOEOALGO_H_
-#define MOEOALGO_H_
+#ifndef MOEOALGOFINALIZED_H_
+#define MOEOALGOFINALIZED_H_
+
+#include <eoPop.h>
 
 /**
- * Abstract class for multi-objective algorithms.
+ * Interface for algorithms that support post-integration finalization.
+ *
+ * Algorithms that need to recompute internal state (fitness assignments,
+ * diversity metrics, etc.) after external population changes should
+ * inherit from this interface and implement finalize().
  */
-class moeoAlgo
+template <class MOEOT>
+class moeoAlgoFinalized
 {
 public:
-    virtual ~moeoAlgo() = default;
+    virtual ~moeoAlgoFinalized() = default;
+
+    /**
+     * Recompute algorithm-specific state after external population changes.
+     *
+     * @param _pop the population to finalize
+     */
+    virtual void finalize(eoPop<MOEOT>& _pop) = 0;
 };
 
-#endif /*MOEOALGO_H_*/
+#endif /*MOEOALGOFINALIZED_H_*/

--- a/moeo/src/algo/moeoNSGAII.h
+++ b/moeo/src/algo/moeoNSGAII.h
@@ -48,6 +48,7 @@
 #include <eoPopEvalFunc.h>
 #include <eoSGAGenOp.h>
 #include <algo/moeoEA.h>
+#include <algo/moeoAlgoFinalized.h>
 #include <diversity/moeoFrontByFrontCrowdingDiversityAssignment.h>
 #include <fitness/moeoDominanceDepthFitnessAssignment.h>
 #include <replacement/moeoElitistReplacement.h>
@@ -59,7 +60,7 @@
  * This class builds the NSGA-II algorithm only by using the fine-grained components of the ParadisEO-MOEO framework.
  */
 template < class MOEOT >
-class moeoNSGAII: public moeoEA < MOEOT >
+class moeoNSGAII: public moeoEA < MOEOT >, public moeoAlgoFinalized < MOEOT >
 {
 public:
 
@@ -157,8 +158,6 @@ public:
         fitnessAssignment(_pop);
         diversityAssignment(_pop);
     }
-
-    bool hasFinalize() const override { return true; }
 
 protected:
 

--- a/moeo/src/algo/moeoNSGAII.h
+++ b/moeo/src/algo/moeoNSGAII.h
@@ -148,6 +148,17 @@ public:
         while (continuator (_pop));
     }
 
+    /**
+     * Recompute fitness and diversity assignments on the population.
+     * Useful after integrating immigrants from an island model.
+     * @param _pop the population to finalize
+     */
+    void finalize(eoPop<MOEOT>& _pop) override {
+        fitnessAssignment(_pop);
+        diversityAssignment(_pop);
+    }
+
+    bool hasFinalize() const override { return true; }
 
 protected:
 

--- a/moeo/src/algo/moeoPopAlgo.h
+++ b/moeo/src/algo/moeoPopAlgo.h
@@ -48,13 +48,6 @@
 template < class MOEOT >
 class moeoPopAlgo : public moeoAlgo, public eoAlgo < MOEOT >
 {
-public:
-    /**
-     * Recompute fitness/diversity after external population changes (e.g. immigrant integration).
-     * Default implementation is a no-op. Override in subclasses that need it.
-     * @param _pop the population to finalize
-     */
-    virtual void finalize(eoPop<MOEOT>&) {}
 };
 
 #endif /*MOEOPOPALGO_H_*/

--- a/moeo/src/algo/moeoPopAlgo.h
+++ b/moeo/src/algo/moeoPopAlgo.h
@@ -47,6 +47,14 @@
  */
 template < class MOEOT >
 class moeoPopAlgo : public moeoAlgo, public eoAlgo < MOEOT >
-  {};
+{
+public:
+    /**
+     * Recompute fitness/diversity after external population changes (e.g. immigrant integration).
+     * Default implementation is a no-op. Override in subclasses that need it.
+     * @param _pop the population to finalize
+     */
+    virtual void finalize(eoPop<MOEOT>&) {}
+};
 
 #endif /*MOEOPOPALGO_H_*/


### PR DESCRIPTION
## Summary

Adds a `finalize()` extension point to the multi-objective algorithm
hierarchy, allowing algorithms to perform post-processing after external
population modifications.

- `moeoAlgo`: virtual destructor + `hasFinalize() const` (default false)
- `moeoPopAlgo<MOEOT>`: virtual `finalize(eoPop<MOEOT>&)` (default no-op)
- `moeoNSGAII`: implements `finalize()` to recompute dominance-depth
  fitness and crowding diversity assignments

## Motivation

In island model configurations, immigrant individuals are integrated into
an island's population between generations. NSGA-II's fitness and diversity
values become stale after integration — the non-dominated sorting ranks and
crowding distances no longer reflect the actual population composition.
Without recomputation, selection pressure degrades until the next natural
generation boundary.

The `finalize()`/`hasFinalize()` pattern lets the island model trigger
recomputation only on algorithms that need it, without coupling the island
infrastructure to specific algorithm internals.

## Changes

| File | Change |
|---|---|
| `moeo/src/algo/moeoAlgo.h` | Added virtual destructor, `hasFinalize() const` |
| `moeo/src/algo/moeoPopAlgo.h` | Added `virtual void finalize(eoPop<MOEOT>&) {}` |
| `moeo/src/algo/moeoNSGAII.h` | Override: recomputes `fitnessAssignment` + `diversityAssignment` |