### PR TITLE
feat(smp): add SerializableBase for MPI population transfer

### DIFF
--- a/smp/src/SerializableBase.h
+++ b/smp/src/SerializableBase.h
@@ -1,11 +1,11 @@
 /*
-<smp.h>
+<SerializableBase.h>
 Copyright (C) DOLPHIN Project-Team, INRIA Lille - Nord Europe, 2006-2012
 
-Alexandre Quemy
+Eremey Valetov
 
 This software is governed by the CeCILL license under French law and
-abiding by the rules of distribution of free software.  You can  ue,
+abiding by the rules of distribution of free software.  You can  use,
 modify and/ or redistribute the software under the terms of the CeCILL
 license as circulated by CEA, CNRS and INRIA at the following URL
 "http://www.cecill.info".
@@ -27,33 +27,33 @@ ParadisEO WebSite : http://paradiseo.gforge.inria.fr
 Contact: paradiseo-help@lists.gforge.inria.fr
 */
 
-#ifndef SMP_H
-#define SMP_H
+#ifndef SERIALIZABLE_BASE_H
+#define SERIALIZABLE_BASE_H
 
-#include <MWModel.h>
-#include <scheduler.h>
-#include <SerializableBase.h>
-#include <islandModel.h>
-#include <islandModelWrapper.h>
-#include <island.h>
-#include <abstractIsland.h>
-#include <migPolicy.h>
-#include <intPolicy.h>
-#include <policyElement.h>
-#include <islandNotifier.h>
-#include <notifier.h>
+#include <serial/eoSerial.h>
+#include <string>
 
-// Topologies
-#include <topology/topology.h>
-#include <topology/complete.h>
-#include <topology/ring.h>
-#include <topology/star.h>
-#include <topology/hypercubic.h>
-#include <topology/mesh.h>
-#include <topology/customBooleanTopology.h>
-#include <topology/customBooleanTopology.h>
+/**
+ * Wrapper that makes any type T serializable via ParadisEO's eoserial framework.
+ * Used by MPI_IslandModel to serialize/deserialize populations for inter-process transfer.
+ */
+template<class T>
+class SerializableBase : public eoserial::Persistent {
+public:
+    SerializableBase();
+    SerializableBase(T base);
+    virtual ~SerializableBase();
 
-// Continuators
-#include <sharedFitContinue.h>
+    operator T&();
+    void setValue(const T& newValue);
 
-#endif
+    void unpack(const eoserial::Object* obj) override;
+    eoserial::Object* pack() const override;
+
+private:
+    T _value;
+};
+
+#include "SerializableBase.tpp"
+
+#endif // SERIALIZABLE_BASE_H

--- a/smp/src/SerializableBase.tpp
+++ b/smp/src/SerializableBase.tpp
@@ -1,0 +1,46 @@
+/*
+<SerializableBase.tpp>
+Copyright (C) DOLPHIN Project-Team, INRIA Lille - Nord Europe, 2006-2012
+
+Eremey Valetov
+
+This software is governed by the CeCILL license under French law and
+abiding by the rules of distribution of free software.  You can  use,
+modify and/ or redistribute the software under the terms of the CeCILL
+license as circulated by CEA, CNRS and INRIA at the following URL
+"http://www.cecill.info".
+
+ParadisEO WebSite : http://paradiseo.gforge.inria.fr
+Contact: paradiseo-help@lists.gforge.inria.fr
+*/
+
+template<class T>
+SerializableBase<T>::SerializableBase() : _value() {}
+
+template<class T>
+SerializableBase<T>::SerializableBase(T base) : _value(std::move(base)) {}
+
+template<class T>
+SerializableBase<T>::~SerializableBase() = default;
+
+template<class T>
+SerializableBase<T>::operator T&() {
+    return _value;
+}
+
+template<class T>
+void SerializableBase<T>::setValue(const T& newValue) {
+    _value = newValue;
+}
+
+template<class T>
+void SerializableBase<T>::unpack(const eoserial::Object* obj) {
+    eoserial::unpack(*obj, "value", _value);
+}
+
+template<class T>
+eoserial::Object* SerializableBase<T>::pack() const {
+    eoserial::Object* obj = new eoserial::Object;
+    obj->add("value", eoserial::make(_value));
+    return obj;
+}


### PR DESCRIPTION
## Summary

Adds `SerializableBase<T>`, a template wrapper that makes any type `T`
serializable via ParadisEO's `eoserial::Persistent` interface.

## Motivation

The MPI island model (#86) needs to transfer `eoPop<EOT>` between MPI
ranks. ParadisEO's serialization framework (`eoserial`) provides
`pack()`/`unpack()` for converting objects to/from a JSON-like intermediate
representation, but `eoPop` doesn't directly implement
`eoserial::Persistent`. `SerializableBase` bridges this gap — it wraps any
`T` that has `eoserial` support and exposes the `Persistent` interface for
use with `eo::mpi`'s send/recv.

## Changes

| File | Change |
|---|---|
| `smp/src/SerializableBase.h` | New — class declaration |
| `smp/src/SerializableBase.tpp` | New — template implementation |
| `smp/src/smp.h` | Added `#include <SerializableBase.h>` |