### PR TITLE
Fix broken links and update outdated URLs across documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,9 +19,8 @@ Contribution Workflow
 
 The maintainer(s) will try to answer under a couple of weeks, if not, do not hesitate to send an e-mail.
 
-If you're not familiar with Git and merge requests, start by cloning one of the main repository:
+If you're not familiar with Git and merge requests, start by cloning the main repository:
 - `git clone https://github.com/nojhan/paradiseo.git`
-- `git clone https://scm.gforge.inria.fr/anonscm/git/paradiseo/paradiseo.git`
 
 
 Git workflow
@@ -38,7 +37,7 @@ git checkout -b <my_feature> # Always work on a dedicated branch.
 git commit <whatever>
 mkdir build
 cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -BUILD_TESTING=ON -DENABLE_CMAKE_TESTING=ON .. && make && ctest # Always test.
+cmake -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DENABLE_CMAKE_TESTING=ON .. && make && ctest # Always test.
 cd ..
 git pull origin master # Always check that your modification still merges.
 ```
@@ -46,7 +45,7 @@ git pull origin master # Always check that your modification still merges.
 If everything went without error, you can either send the patch or submit a merge request.
 To do so, you can either:
 - submit a "pull request" on Github: [nojhan/paradiseo](https://github.com/nojhan/paradiseo),
-- or send a patch on the [ParadisEO mailing list](https://lists.gforge.inria.fr/cgi-bin/mailman/listinfo/paradiseo-users).
+- or [open an issue](https://github.com/nojhan/paradiseo/issues) to discuss your proposed changes.
 
 See below for the details.
 
@@ -79,6 +78,6 @@ git pull origin master
 git diff master <my_feature> > my_feature.patch
 ```
 
-Then send the `my_feature.patch` (along with your explanations about why the maintainer should merge your modifications)
-to the [mailing list](https://lists.gforge.inria.fr/cgi-bin/mailman/listinfo/paradiseo-users).
+Then [open an issue](https://github.com/nojhan/paradiseo/issues) with `my_feature.patch` attached
+(along with your explanations about why the maintainer should merge your modifications).
 

--- a/ForRelease
+++ b/ForRelease
@@ -39,7 +39,7 @@ When reaching stable versions:
 - Post the message to:
     - EO news https://sourceforge.net/news/?group_id=9775
     - EO mailing list: eodev-main@lists.sourceforge.net
-    - ParadisEO mailing list: paradiseo-users@lists.gforge.inria.fr
+    - ParadisEO: https://github.com/nojhan/paradiseo/issues
     - EC-digest maling list: ec-digest-l@listserv.gmu.edu
     - JET mailing list: jet@inria.fr
 

--- a/ForRelease
+++ b/ForRelease
@@ -22,7 +22,7 @@ When reaching stable versions:
     insanely fast.
 
     Learn more about EO on the official website:
-    http://eodev.sourceforge.net/
+    https://nojhan.github.io/paradiseo/
 
     You will find the release x.y.z at the following address:
     https://sourceforge.net/projects/eodev/files/eo/

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -9,9 +9,9 @@ Just put it somewhere on your development computer, compile it from here and ind
 Build
 -----
 
-Paradiseo is mainly developed for Linux, on which it is straightforward to install a C++ build chain. For example, on Ubuntu 18.04:
+Paradiseo is mainly developed for Linux, on which it is straightforward to install a C++ build chain. For example, on Ubuntu:
 ```bash
-sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev
+sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev
 ```
 
 Paradiseo use the CMake build system, so building it should be as simple as:
@@ -67,7 +67,7 @@ Feel free to test with another compiler and to send us your report.
 
 As of today, we cannot guarantee that it will be easy to
 install ParadisEO under Windows if you're a beginner.
-There is still some (possibly outdated) help about oldest version on the [Website](http://paradiseo.gforge.inria.fr/).
+There is still some (possibly outdated) help about oldest version on the [Website](https://nojhan.github.io/paradiseo/).
 
 If you know how to install a working compiler and the dependencies,
 you may follow the same steps than the Linux process below.
@@ -89,9 +89,9 @@ Some features are only available if some dependencies are installed:
 - Doxygen is needed to build the API documentation, and you should also install graphviz if you want the class relationship diagrams.
 - GNUplot is needed to have the… GNUplot graphs at checkpoints.
 
-To install all those dependencies at once under Ubuntu (18.04), just type:
+To install all those dependencies at once under Ubuntu, just type:
 ```bash
-sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev.
+sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev
 ```
 
 
@@ -144,19 +144,9 @@ this can be helpful if you don't need other modules with more complex dependenci
 Shared Memory Processing (SMP) module
 -------------------------------------
 
-The SMP module requires gcc 4.7 or higher. This is due to the fact that it uses the new C++ standard.
-
-At the moment, the SMP module does not work on Windows or Mac OS X since MinGW does not provide support for std::thread and Apple does not supply a recent version of gcc (but you can try to compile gcc 4.7 by yourself).  
+ParadisEO requires C++17, so any modern compiler (GCC, Clang) should work.
 
 To enable the compilation of the SMP module, just set the `SMP` option.
-
-Depending on your distribution, you might have to give to CMake the path of gcc and g++ 4.7.
-This is the case for Ubuntu 12.04 LTS for instance.
-
-If you are in that case and assuming you have a standard path for gcc et g++ 4.7:
-```bash
-cmake .. -DSMP=true -DCMAKE_C_COMPILER=/usr/bin/gcc-4.7 -DCMAKE_CXX_COMPILER=/usr/bin/g++-4.7
-```
 
 Estimating Distribution Objects (EDO) module
 --------------------------------------------
@@ -178,12 +168,12 @@ Targets for the build system (usually `make`) are:
 - `doc` for all documentations,
 - `doc-eo` for building EO documentation,
 - `doc-mo` for MO,
-- `doc-edo` for MO,
+- `doc-edo` for EDO,
 - `doc-moeo` for MOEO,
 - `doc-smp` for SMP.
 
 Each documentation are generated separatly in the module build folder.
-For instance, after the generation of the MO documentation, you will find it in `build/paradise-mo/doc`.
+For instance, after the generation of the MO documentation, you will find it in `build/mo/doc`.
 
 Examples
 --------

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ It focus on the efficiency of the implementation of solvers, by providing:
 
 # Very Quick Start
 
-1. Use a recent Linux, like an Ubuntu.
-2. `sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev`
+1. Use a recent Linux, like Ubuntu.
+2. `sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev`
 3. From the Paradiseo directory: `mkdir build ; cd build ; cmake -D CMAKE_BUILD_TYPE=Release -DEDO=ON .. && make -j`
 4. Copy-paste this CMA-ES code in `cmaes.cpp`:
 ```cpp
@@ -173,7 +173,7 @@ Stable versions should however work on Windows and any Unix-like operating syste
 
 # Code
 
-The latest stable version is on the official Git repository of INRIA: `git clone git://scm.gforge.inria.fr/paradiseo/paradiseo.git`
+The latest version is on the official Git repository: `git clone https://github.com/nojhan/paradiseo.git`
 
 ## Dependencies
 
@@ -187,7 +187,7 @@ Some features are only available if some dependencies are installed:
 - Doxygen is needed to build the API documentation, and you should also install graphviz if you want the class relationship diagrams.
 - GNUplot is needed to have the… GNUplot graphs at checkpoints.
 
-To install all those dependencies at once under Ubuntu (18.04), just type: `sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev`.
+To install all those dependencies at once under Ubuntu, just type: `sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev`.
 
 ## Compilation
 
@@ -237,7 +237,7 @@ benchmark libraries are in `paradiseo/problems`.
 
 For academic articles, books, more tutorials, presentations slides,
 real life example of solvers and contact information,
-please see the web site (available in `paradiseo/website/index.html`).
+please see the web site (available in `docs/index.html`).
 
 
 # Citing Paradiseo

--- a/cmake/Package.cmake
+++ b/cmake/Package.cmake
@@ -53,7 +53,7 @@ set(CPACK_PACKAGE_DESCRIPTION "ParadisEO is a white-box object-oriented framewor
 set(CPACK_RESOURCE_FILE_LICENSE "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE")
 set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "A Software Framework for Metaheuristics")
 set(CPACK_PACKAGE_VENDOR "Inria/Thales")
-set(CPACK_PACKAGE_CONTACT "paradiseo-help@lists.gforge.inria.fr")
+set(CPACK_PACKAGE_CONTACT "https://github.com/nojhan/paradiseo/issues")
 set(CPACK_PACKAGE_VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH})
 set(CPACK_STRIP_FILES ${PACKAGE_NAME})
 set(CPACK_SOURCE_STRIP_FILES "bin/${PROJECT_NAME}")

--- a/docs/index.html
+++ b/docs/index.html
@@ -136,7 +136,7 @@
     <p>As <em class="logo">Paradis<span class="logo_eo">eo</span></em> is a development framework, you do not really need to install it on all your systems. Just put it somewhere on your development computer, compile it from here and indicate where to find it to your favorite build system.</p>
 
     <p><em class="logo">Paradis<span class="logo_eo">eo</span></em> is mainly developed for Linux, on which it is straightforward to install a C++ build chain.
-    For example, on Ubuntu 18.04: <code class="command">sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev</code></p>
+    For example, on Ubuntu: <code class="command">sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev</code></p>
 
     <p><em class="logo">Paradis<span class="logo_eo">eo</span></em> use the CMake build system, so building it should be as simple as:
     <code class="command">mkdir build ; cd build ; cmake -DEDO=ON .. && make -j</code></p>
@@ -234,11 +234,12 @@
     <div id="Gethelp">
     <h2><a name="Gethelp"></a>Get help</h2>
 
-    <p>If you need <em>immediate support or have any question</em>, the best way to get
-    answers is to send an email to <a href='mailto:paradiseo-help@lists.gforge.inria.fr'>paradiseo-help@lists.gforge.inria.fr</a>. You can also <a href='http://lists.gforge.inria.fr/pipermail/paradiseo-help/'>consult the help archives</a>, subscribe to our <a href='http://lists.gforge.inria.fr/cgi-bin/mailman/listinfo/paradiseo-users'>(low traffic) mailing-list</a> or <a href='http://lists.gforge.inria.fr/pipermail/paradiseo-users/'>consult its archives</a>.
+    <p>If you need <em>immediate support or have any question</em>, you can:
+    <ul>
+        <li><a href="https://github.com/nojhan/paradiseo/issues">Open an issue</a> on GitHub.</li>
+        <li>Join the official <a href="https://app.element.io/#/room/#paradiseo:matrix.org">Matrix chatroom</a> (<em>#paradiseo:matrix.org</em>), using the online webchat or your favorite <a href="https://element.io">Element.io</a> client.</li>
+    </ul>
     </p>
-
-    <p>Alternatively, you can join us on the official chatroom. You can try the <a href="https://app.element.io/#/room/#paradiseo:matrix.org">online webchat app</a>, or if you already use <a href="https://element.io">Element.io</a>, you can directly connect to the <em>#paradiseo:matrix.org</em> multi-user chatroom with your favorite client.</p>
 
     </div>
     </div>
@@ -531,7 +532,7 @@
 
     <p>Recent versions of <em class="logo">Paradis<span class="logo_eo">eo</span></em> uses the <a href="http://www.cmake.org">CMake</a> portable build system, that permits to easily generate a build script for your environment.</p>
 
-    <p> If you have tested <em class="logo">Paradis<span class="logo_eo">eo</span></em> on a system not listed here, please <a href="mailto:eodev-main@lists.sourceforge.net?subject=test-report">let
+    <p> If you have tested <em class="logo">Paradis<span class="logo_eo">eo</span></em> on a system not listed here, please <a href="https://github.com/nojhan/paradiseo/issues">let
         us know</a>. </p>
     </div>
 
@@ -861,7 +862,7 @@
         <li>
             <p>The core EO module is described in the following scientific article:
             <blockquote>M. Keijzer, J.J. Merelo, G. Romero, G., M. Schoenauer,
-                <a href= "http://www.lri.fr/~marc/EO/EO-EA01.ps.gz">Evolving
+                <a href= "https://doi.org/10.1007/3-540-46033-0_13">Evolving
                     objects: A general purpose evolutionary computation
                     library</a>, <i>Artificial Evolution</i>, <b>2310</b>, 829--888 (2002).</blockquote>
             </p>
@@ -875,7 +876,7 @@
 
         <li>
             <p>The multi-objective module (MOEO) is described in:
-            <blockquote>A. Liefooghe, M. Basseur, L. Jourdan, E.-G. Talbi, <a href="http://www2.lifl.fr/~jourdan/publi/jourdan_EMO07_A.pdf"><em class="logo">Paradis<span class="logo_eo">eo</span></em>-MOEO: A Framework for Evolutionary Multi-objective Optimization</a>, EMO 2007, LNCS Vol. 4403, pp. 386-400, Matsushima, Japan.</blockquote>
+            <blockquote>A. Liefooghe, M. Basseur, L. Jourdan, E.-G. Talbi, <a href="https://doi.org/10.1007/978-3-540-70928-2_31"><em class="logo">Paradis<span class="logo_eo">eo</span></em>-MOEO: A Framework for Evolutionary Multi-objective Optimization</a>, EMO 2007, LNCS Vol. 4403, pp. 386-400, Matsushima, Japan.</blockquote>
             </p>
         </li>
 
@@ -887,7 +888,7 @@
 
         <li>
             <p>A book about metaheuristics use <em class="logo">Paradis<span class="logo_eo">eo</span></em> as its framework of choice and explains in details several of its concepts, along with algorithmics content:
-            <blockquote>El-Ghazali Talbi, <a href="http://eu.wiley.com/WileyCDA/WileyTitle/productCd-0470278587.html">Metaheuristics: from design to implementation</a>, Wiley, 2009.
+            <blockquote>El-Ghazali Talbi, <a href="https://www.wiley.com/en-us/Metaheuristics:+From+Design+to+Implementation-p-9780470278581">Metaheuristics: from design to implementation</a>, Wiley, 2009.
 (624pp),
 ISBN: 978-0-470-27858-1</blockquote>
             </p>
@@ -1026,24 +1027,24 @@ undiscovered knowledge.
 <h3>Paradiseo-EO</h3>
 
 <ul>
-    <li> A functional and "philosophical" overview of the EO module was presented at <a href="http://www.cmap.polytechnique.fr/%7Eea01/">EA'01 conference</a>.
-    You can download <a href="https://www.lri.fr/~marc/EO/eo/doc/EO_EA2001.pdf">the paper</a>
-    or <a href="https://www.lri.fr/~marc/EO/eo/doc/LeCreusot.pdf">the
-        slides</a>.</li>
-<li><strong><a href='http://paradiseo.gforge.inria.fr/addon/paradiseo-eo/concepts/paradiseo-eo-design.pdf'>Metaheuristics for Combinatorial Optimization</a></strong> [pdf] by E-G. Talbi and S.Cahon: provides general concept on metaheuristics for combinatorial optimization.
-</li><li><strong><a href='http://paradiseo.gforge.inria.fr/addon/paradiseo-eo/concepts/paradiseo-eo-implem.pdf'>Reusable Design of Metaheuristics</a></strong> [pdf] by S.Cahon, E-G. Talbi and N. Melab: explains how to use Paradiseo-EO with a simple example.
+    <li> A functional and "philosophical" overview of the EO module was presented at EA'01 conference.
+    You can download <a href="https://github.com/nojhan/paradiseo/blob/master/eo/doc/EO_EA2001.pdf">the paper</a>
+    or <a href="https://github.com/nojhan/paradiseo/blob/master/eo/doc/LeCreusot.pdf">the
+        slides</a> (also available locally in <code>eo/doc/</code>).</li>
+<li><strong>Metaheuristics for Combinatorial Optimization</strong> [pdf] by E-G. Talbi and S.Cahon: provides general concept on metaheuristics for combinatorial optimization. [No longer available online]
+</li><li><strong>Reusable Design of Metaheuristics</strong> [pdf] by S.Cahon, E-G. Talbi and N. Melab: explains how to use Paradiseo-EO with a simple example. [No longer available online]
 </li></ul>
 
 <h3>Paradiseo-MO</h3>
 
-<ul><li><strong><a href='http://paradiseo.gforge.inria.fr/addon/paradiseo-mo/concepts/paradiseo-newmo-design.pdf'>Reusable Design of Local Searches and Tools for Landscape Analysis</a></strong> [pdf] by S.Verel, A.Liefooghe and J.Humeau: explains the new design of Paradiseo-MO.
+<ul><li><strong>Reusable Design of Local Searches and Tools for Landscape Analysis</strong> [pdf] by S.Verel, A.Liefooghe and J.Humeau: explains the new design of Paradiseo-MO. [No longer available online]
 </li><li><strong><a href='https://hal.inria.fr/hal-00665421v2'><em class="logo">Paradis<span class="logo_eo">eo</span></em>-MO: From fitness landscape analysis to efficient local search algorithms</a></strong> [pdf] by J.Humeau, A.Liefooghe, E-G. Talbi, and S.Verel (presented at ROADEF 2012).
 </li></ul>
 
 <h3>Paradiseo-MOEO</h3>
 
-<ul><li><strong><a href='http://paradiseo.gforge.inria.fr/addon/paradiseo-moeo/concepts/paradiseo-moeo-design.pdf'>Metaheuristics for Multi-objective Optimization</a></strong> [pdf] by E.-G. Talbi and the <em class="logo">Paradis<span class="logo_eo">eo</span></em> group: presents multi-objective optimization concepts, a taxonomy of resolution methods and gives performance evaluation examples.
-</li><li><strong><a href='http://paradiseo.gforge.inria.fr/addon/paradiseo-moeo/concepts/paradiseo-moeo-implem.pdf'>Reusable Design of Metaheuristics for Multi-objective Optimization</a></strong> [pdf] by E.-G. Talbi and the <em class="logo">Paradis<span class="logo_eo">eo</span></em> group: explains how to implement metaheuristics for multi-objective optimization using Paradiseo-MOEO through a simple example.
+<ul><li><strong>Metaheuristics for Multi-objective Optimization</strong> [pdf] by E.-G. Talbi and the <em class="logo">Paradis<span class="logo_eo">eo</span></em> group: presents multi-objective optimization concepts, a taxonomy of resolution methods and gives performance evaluation examples. [No longer available online]
+</li><li><strong>Reusable Design of Metaheuristics for Multi-objective Optimization</strong> [pdf] by E.-G. Talbi and the <em class="logo">Paradis<span class="logo_eo">eo</span></em> group: explains how to implement metaheuristics for multi-objective optimization using Paradiseo-MOEO through a simple example. [No longer available online]
 </li></ul>
 
 <!-- <h3>Paradiseo-PEO</h3> -->
@@ -1068,30 +1069,32 @@ undiscovered knowledge.
 
 <h3>Tutorials on EO (evolutionary algorithms module)</h3>
 
-<ul><li><a href='http://eodev.sourceforge.net/eo/tutorial/html/eoTutorial.html'>EO Lesson1-5</a> Implement a GA
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoEOLesson6part1'>EO Lesson6 first part</a> Implement a real PSO algorithm
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoEOLesson6part2'>EO Lesson6 second part</a> Implement a binary PSO algorithm
+<ul><li><a href='https://github.com/nojhan/paradiseo/blob/master/eo/tutorial/html/eoTutorial.html'>EO Lessons 1–5</a> Implement a GA (also available locally in <code>eo/tutorial/html/</code>)
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/eo/tutorial/Lesson6'>EO Lesson 6</a> Implement real and binary PSO algorithms (see <code>RealPSO.cpp</code> and <code>BinaryPSO.cpp</code>)
 </li></ul>
 
 <h3>Tutorials on MO (local search module)</h3>
 
-</p><ul><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson1'>MO Lesson1</a> Hill Climber
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson2'>MO Lesson2</a> Neighborhoods (classical and indexed)
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson3'>MO Lesson3</a> Simulated Annealing and Checkpointing
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson4'>MO Lesson4</a> Tabu Search
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson5'>MO Lesson5</a> Iterated Local Search
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson6'>MO Lesson6</a> Fitness Landscapes Analysis
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOLesson7'>MO Lesson7</a> Hybrid Lesson
+</p><ul><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson1'>MO Lesson 1</a> Hill Climber
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson2'>MO Lesson 2</a> Neighborhoods (classical and indexed)
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson3'>MO Lesson 3</a> Simulated Annealing and Checkpointing
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson4'>MO Lesson 4</a> Tabu Search
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson5'>MO Lesson 5</a> Iterated Local Search
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson6'>MO Lesson 6</a> Fitness Landscapes Analysis
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/mo/tutorial/Lesson7'>MO Lesson 7</a> Hybrid Lesson
 </li></ul>
 
 <h3>Tutorials on MOEO (multi-objective module)</h3>
 
-</p><ul><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOEOLesson1'>MOEO Lesson1</a> Implement NSGA, NSGA-II and IBEA for the SCH1 problem
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOEOLesson2'>MOEO Lesson2</a> Evolutionary Algorithms for the flow-shop scheduling problem
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOEOLesson3'>MOEO Lesson3</a> Evolutionary Algorithms with a user-friendly parameter file
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoMOEOLesson4'>MOEO Lesson4</a> Dominance-based Local Search for the flow-shop scheduling problem
-</li></ul><p>Tutorials SMP: <span  style='color: red;'>  new</span>
-</p><ul><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoSMPLesson1'>SMP Lesson1</a> Algorithm wrapping with Master / Workers model
+</p><ul><li><a href='https://github.com/nojhan/paradiseo/tree/master/moeo/tutorial/Lesson1'>MOEO Lesson 1</a> Implement NSGA, NSGA-II and IBEA for the SCH1 problem
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/moeo/tutorial/Lesson2'>MOEO Lesson 2</a> Evolutionary Algorithms for the flow-shop scheduling problem
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/moeo/tutorial/Lesson3'>MOEO Lesson 3</a> Evolutionary Algorithms with a user-friendly parameter file
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/moeo/tutorial/Lesson4'>MOEO Lesson 4</a> Dominance-based Local Search for the flow-shop scheduling problem
+</li></ul><p>Tutorials SMP:
+</p><ul><li><a href='https://github.com/nojhan/paradiseo/tree/master/smp/tutorial/Lesson1'>SMP Lesson 1</a> Algorithm wrapping with Master / Workers model
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/smp/tutorial/Lesson2'>SMP Lesson 2</a> Homogeneous island model
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/smp/tutorial/Lesson3'>SMP Lesson 3</a> Heterogeneous island model
+</li><li><a href='https://github.com/nojhan/paradiseo/tree/master/smp/tutorial/Lesson4'>SMP Lesson 4</a> Island topology
 </li></ul>
 
 <h3>Tutorials on parallelization</h3>
@@ -1104,12 +1107,8 @@ undiscovered knowledge.
             <a href="https://endomorphis.me/island-model-with-paradiseo-components-and-basics-en.html">2. components and basics</a>,
             <a href="https://endomorphis.me/island-model-with-paradiseo-advanced-island-model-manipulations-en.html">3. advanced island model manipulations</a>.
         </li>
-        <li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOIntro'>PEO Intro</a> Technical introduction</li>
-        <!-- </li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson1'>PEO Lesson1</a> Multistart over a MO, Packing and Unpacking  (use old-mo) -->
-        <li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson2'>PEO Lesson2</a> Multistart over an evolutionary algorithm</li>
-        <li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson3'>PEO Lesson3</a> Parallel evaluation </li>
-        <!-- </li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson4'>PEO Lesson4</a> Parallel transformation (use old-mo) -->
-        <li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson5'>PEO Lesson5</a> Island model</li>
+        <!-- PEO tutorials are no longer available — the PEO module has been removed from ParadisEO.
+             See the SMP module tutorials above for current parallelization features. -->
         <!-- </li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoPEOLesson6'>PEO Lesson6</a> Hybridization (use old-mo) -->
         <!-- </li></ul><p><span  style='display: none;'>GPU tutorials: </span> -->
         <!-- <span  style='display: none;'>*<a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoGPULesson1'>GPU Lesson1</a> CUDA installation and configuration</span> -->
@@ -1124,9 +1123,9 @@ undiscovered knowledge.
 
 <h3>Utilities</h3>
 
-</p><ul><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoUtilsParamFiles'>Utils Lesson1</a> Using configuration files
-</li><li><a href='http://paradiseo.gforge.inria.fr/index.php?n=Doc.TutoUtilsStats'>Utils Lesson2</a> Using statistics
-</li></ul>
+<!-- Utils tutorials were hosted on the GForge wiki only and are no longer available online.
+     See eo/src/utils/ for parameter file and statistics source code. -->
+
     </div>
 
     <div id="API">
@@ -1134,16 +1133,7 @@ undiscovered knowledge.
 
     <p>The heart of <em class="logo">Paradis<span class="logo_eo">eo</span></em> is a set of classes implementing operators. Each module has a separate API documentation. If you want to browse the features and find which class to use, this is the right entry point</p>
 
-    <p>For your convenience, you can browse an online API doc for <em class="logo">Paradis<span class="logo_eo">eo</span></em> version 2.0:
-    <ul>
-        <li><a href='http://paradiseo.gforge.inria.fr/addon/eo/doc/index.html'>doc-eo</a> (includes doc on EO, PSO and EDO)</li>
-        <li><a href='http://paradiseo.gforge.inria.fr/addon/mo/doc/index.html'>doc-mo</a> </li>
-        <li><a href='http://paradiseo.gforge.inria.fr/addon/moeo/doc/index.html'>doc-moeo</a> </li>
-        <li><a href='http://paradiseo.gforge.inria.fr/addon/smp/doc/index.html'>doc-smp</a> </li>
-    </ul>
-    </p>
-
-    <p>Note that if you want to find the API documentation for the version you have at hand, just build the <code class="command">make doc</code> target and open <code>paradiseo/&lt;build&gt;/&lt;module&gt;/doc/html/index.html</code> in your web browser.</p>
+    <p>The previously hosted online API docs (v2.0) are no longer available. To generate the API documentation for your version, build the <code class="command">make doc</code> target and open <code>paradiseo/&lt;build&gt;/&lt;module&gt;/doc/html/index.html</code> in your web browser. Per-module targets are also available: <code>make doc-eo</code>, <code>make doc-mo</code>, <code>make doc-moeo</code>, <code>make doc-smp</code>, <code>make doc-edo</code>.</p>
     </div>
 
     <div id="Examples">
@@ -1151,9 +1141,8 @@ undiscovered knowledge.
 
     <p>If you want to see examples of real solvers:
     <ul>
-        <li>The <a href="http://paradiseo.gforge.inria.fr/index.php?n=Problems.Problems">examples page</a> on INRIA <em class="logo">Paradis<span class="logo_eo">eo</span></em> pages (with explanations).</li>
-        <li>The <a href="https://gforge.inria.fr/frs/?group_id=145">contributed code</a> on the project page.</li>
-        <li>The <a href="https://github.com/nojhan/descarwin">Descarwin</a> project hold the "DaE" planning solver,
+        <li>The <a href="https://github.com/nojhan/paradiseo/tree/master/problems">problems directory</a> in the repository contains benchmark problem implementations (DTLZ, NK landscapes, QAP, etc.).</li>
+        <li>The <a href="https://github.com/nojhan/descarwin">Descarwin</a> project holds the "DaE" planning solver,
         which is implemented with <em class="logo">Paradis<span class="logo_eo">eo</span></em> and won the International Planning Competition.</li>
     </ul>
     </p>
@@ -1172,7 +1161,7 @@ undiscovered knowledge.
     <p>The current stable release is version: <a href="https://github.com/nojhan/paradiseo/releases">Paradiseo 3.1.3</a>. Some other releases (older or newer) can be found on <a href="https://github.com/nojhan/paradiseo/tags">GitHub/paradiseo/releases</a>.</p>
 
     <p> You can obtain the latest stable and beta version directly via the Git repository:
-    <code class="command">git clone https://github.com/jdreo/paradiseo.git</code>.
+    <code class="command">git clone https://github.com/nojhan/paradiseo.git</code>.
     The release are on the "master" branch.
     </p>
 
@@ -1205,7 +1194,7 @@ undiscovered knowledge.
         </ul>
     </p>
 
-    <p class="excerpt">To install all those dependencies at once under Ubuntu (18.04), just type: <em>sudo apt install g++-8 cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev</em>.  </p>
+    <p class="excerpt">To install all those dependencies at once under Ubuntu, just type: <em>sudo apt install g++ cmake make libeigen3-dev libopenmpi-dev doxygen graphviz libgnuplot-iostream-dev</em>.  </p>
     </div>
 
     <div id="Compilation">
@@ -1253,7 +1242,7 @@ undiscovered knowledge.
 
     <p><em class="logo">Paradis<span class="logo_eo">eo</span></em> development is open and contributions are welcomed.</p>
     <p>The official bug tracker is available on the <a href="https://github.com/nojhan/paradiseo/issues">project page</a>.</p>
-    <p>If you have any question about contributing: subscribe to our <a href='http://lists.gforge.inria.fr/cgi-bin/mailman/listinfo/paradiseo-users'>(low traffic) mailing-list</a>.</p>
+    <p>If you have any question about contributing, <a href='https://github.com/nojhan/paradiseo/issues'>open an issue</a> or join the <a href='https://app.element.io/#/room/#paradiseo:matrix.org'>Matrix chatroom</a>.</p>
 
     </div>
     </div>
@@ -1289,35 +1278,26 @@ undiscovered knowledge.
     <div id="Authors">
     <h2><a name="Authors"></a>Authors</h2>
 
-    <p>The EO module was started in 1999 by the <a href="http://geneura.ugr.es/">Geneura
-        Team</a> at the University of Granada, headed by <a
-        href="http://geneura.ugr.es/%7Ejmerelo/">Juan Julián Merelo</a>. The <a
-        href="http://geneura.ugr.es/~jmerelo/EO.orig.html"
-        >original Web site</a> is also the only place where you
-    will find old releases of <em class="logo">Paradis<span class="logo_eo">eo</span></em> (up to 0.8.7), but beware that it is not
-    compatible at all with the current version. </p>
+    <p>The EO module was started in 1999 by the Geneura
+        Team at the University of Granada, headed by
+        Juan Julián Merelo. </p>
 
-    <p>You can read this <a href="http://geneura.ugr.es/~jmerelo/GAPPT/index.html">
-        PowerPoint presentation</a>, that shows the EO philosophy back then.
-    It includes a Visual Basic (!) macro for evolving objects in Visual Basic
-    for Applications.</p>
-
-    <p>The developement team has then been reinforced by <a
-        href="http://www.cs.vu.nl/~mkeijzer">Maarten Keijzer</a>, the C++
+    <p>The developement team has then been reinforced by
+    Maarten Keijzer (the C++
     wizard who designed the current neat architecture),
-    and <a href="http://www.lri.fr/%7Emarc">Marc Schoenauer</a>
+    and Marc Schoenauer
     (who became a prominent researcher in the evolutionary algorithm community).
-    Later came <a href="http://www.liacs.nl/%7Ejeggermo/">Jeroen Eggermont</a>,
+    Later came Jeroen Eggermont,
     who, among other things, did a lot of work on GP,
     INRIA Dolphin Team, Olivier König, who did a
     lot of useful additions and cleaning of the code
-    and <a href="http://www.jochen-kuepper.de">Jochen Küpper</a>, working on
+    and <a href="https://www.jochen-kuepper.de">Jochen Küpper</a>, working on
     infrastructure maintenance. </p>
 
-    <p><a href="https://www.lifl.fr/~talbi/">El-Ghazali Talbi</a>'s
+    <p>El-Ghazali Talbi's
     INRIA team did a lot of contributions starting from around 2003,
     on their own module collection called <em class="logo">Paradis<span class="logo_eo">eo</span></em>.
-    Thomas Legrand, Sébastien Cahon and <a href="https://www.lifl.fr/~melab">Nouredine Melab</a>
+    Thomas Legrand, Sébastien Cahon and Nouredine Melab
     worked on parallelization modules.
     <a href="https://sites.google.com/site/arnaudliefooghe/">Arnaud Liefooghe</a>
     worked a lot on the multi-objective module and
@@ -1326,7 +1306,7 @@ undiscovered knowledge.
     In the same team, C. C. and J. Boisson made significant contributions.
     Karima Boufaras specifically worked on (now deprecated) GPU tools.</p>
 
-    <p>The (then) EO project was then taken over by <a href="http://johann.dreo.fr">Johann Dreo</a>,
+    <p>The (then) EO project was then taken over by <a href="https://johann.dreo.fr">Johann Dreo</a>,
     who worked with the help of Caner Candan on adding the EDO module.
     Johann and <a href="https://github.com/bnjbvr">Benjamin Bouvier</a> have also designed a
     MPI parallelization module. <a href="https://aquemy.info/">Alexandre Quemy</a>
@@ -1346,14 +1326,13 @@ undiscovered knowledge.
     <p>Some softwares listed here are using <em class="logo">Paradis<span class="logo_eo">eo</span></em>, but they are not maintained by the <em class="logo">Paradis<span class="logo_eo">eo</span></em> team.
     They may not be free softwares.</p>
     <p><ul>
-        <li> <a href="http://geneura.ugr.es/~jmerelo/DegaX/">DegaX</a>
-        is an ActiveX control which embeds <em class="logo">Paradis<span class="logo_eo">eo</span></em> 0.8.4.
+        <li> DegaX was an ActiveX control which embedded <em class="logo">Paradis<span class="logo_eo">eo</span></em> 0.8.4.
         </li>
 
-        <li><a href="https://lsiit.u-strasbg.fr/easea/index.php/EASEA_platform">EASEA</a> was a GUI that permits to build evolutionary algorithm with <em class="logo">Paradis<span class="logo_eo">eo</span></em> or the <a href="http://lancet.mit.edu/ga/">GAlib</a>.
-        It is now a platform that allows program evolutionary algorithms on massively parallel many-core architectures.</li>
+        <li>EASEA was a GUI that permits to build evolutionary algorithm with <em class="logo">Paradis<span class="logo_eo">eo</span></em> or GAlib.
+        It became a platform that allows programming evolutionary algorithms on massively parallel many-core architectures.</li>
 
-        <li><a href="https://gforge.inria.fr/projects/guide">GUIDE</a> is a GUI that allows the generation of evolutionary algorithms. It can use <em class="logo">Paradis<span class="logo_eo">eo</span></em> or <a href="http://cs.gmu.edu/~eclab/projects/ecj/">ECJ</a>.</li>
+        <li>GUIDE was a GUI that allows the generation of evolutionary algorithms. It could use <em class="logo">Paradis<span class="logo_eo">eo</span></em> or <a href="https://cs.gmu.edu/~eclab/projects/ecj/">ECJ</a>.</li>
     </ul>
     </p>
     </div>

--- a/edo/README
+++ b/edo/README
@@ -9,7 +9,7 @@ On Windows write your path with double antislash (ex: C:\\Users\\...)
 
 # Step 2 - Build process
 ------------------------
-ParadisEO is assumed to be compiled. To download ParadisEO, please visit http://paradiseo.gforge.inria.fr/.
+ParadisEO is assumed to be compiled. To download ParadisEO, please visit https://nojhan.github.io/paradiseo/.
 Go to the DO/build/ directory and lunch cmake:
 (Unix)       > cmake ..
 (Windows)    > cmake .. -G"Visual Studio 9 2008"
@@ -22,23 +22,23 @@ Note for windows users: if you don't use VisualStudio 9, enter the name of your 
 In the edo/build/ directory:
 (Unix)       > make
 (Windows)    Open the VisualStudio solution and compile it, compile also the target install.
-You can refer to this tutorial if you don't know how to compile a solution: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+You can refer to this tutorial if you don't know how to compile a solution: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 
 # Step 4 - Execution
 ---------------------
 A toy example is given to test the components. You can run these tests as following.
-To define problem-related components for your own problem, please refer to the tutorials available on the website : http://paradiseo.gforge.inria.fr/.
+To define problem-related components for your own problem, please refer to the tutorials available on the website : https://nojhan.github.io/paradiseo/.
 In the edo/build/ directory:
 (Unix)       > ctest
-Windows users, please refer to this tutorial: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+Windows users, please refer to this tutorial: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 In the directory "application", there are several directory such as eda which instantiate EDA solver.
 
 (Unix) After compilation you can run the binary "build/eda" and see results. Parameters can be modified from command line.
 
 (Windows) Add argument "eda.param" and execute the corresponding algorithms.
-Windows users, please refer to this tutorial: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+Windows users, please refer to this tutorial: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 
 # Documentation

--- a/eo/README
+++ b/eo/README
@@ -1,13 +1,13 @@
 		      EO README FILE
 
 =======================================================================
-	 check latest news at http://eodev.sourceforge.net/
+	 check latest news at https://nojhan.github.io/paradiseo/
 =======================================================================
 
 Welcome to EO, the Evolving Objects library.
 
 The latest news about EO can be found on the sourceforge repository at
-    http://eodev.sourceforge.net/
+    https://nojhan.github.io/paradiseo/
 
 In case of any problem, please e-mail us at
     eodev-main@lists.sourceforge.net

--- a/eo/doc/index.h
+++ b/eo/doc/index.h
@@ -56,7 +56,7 @@ Thus, you can easily build your own algorithm by trying several combination of o
 For a more detailled introduction to the design of %EO you can look at the
 slides from a talk at EA 2001 or at the corresponding
 article in Lecture Notes In Computer Science, 2310, Selected Papers from the 5th European Conference on Artificial Evolution:
-    - http://portal.acm.org/citation.cfm?id=727742
-    - http://eodev.sourceforge.net/eo/doc/LeCreusot.pdf
-    - http://eodev.sourceforge.net/eo/doc/EO_EA2001.pdf
+    - https://doi.org/10.1007/3-540-46033-0_13
+    - LeCreusot.pdf (available in eo/doc/)
+    - EO_EA2001.pdf (available in eo/doc/)
 */

--- a/eo/doc/mainpage.html
+++ b/eo/doc/mainpage.html
@@ -35,23 +35,18 @@ background: #00309c;
         in it, it is very easy to subclass existing abstract or concrete
         classes. </p>
 
-        <p> EO was started by the <a href="http://geneura.ugr.es/">Geneura
-        Team</a> at the University of Granada, headed by <a
-        href="http://geneura.ugr.es/%7Ejmerelo/">Juan Julián Merelo</a>. The <a
-        href="http://geneura.ugr.es/~jmerelo/EO.orig.html"
-        target="_blank">original Web site</a> is also the only place where you
-        will find old releases of EO (up to 0.8.7), but beware that it is not
-        compatible at all with the current version. </p>
+        <p> EO was started by the Geneura
+        Team at the University of Granada, headed by
+        Juan Juli&aacute;n Merelo. </p>
 
-        <p> The developement team has then been reinforced by <a
-        href="http://www.cs.vu.nl/~mkeijzer">Maarten Keijzer</a>, the C++
-        wizzard, and <a href="http://www.lri.fr/%7Emarc">Marc Schoenauer</a>.
-        Later came <a href="http://www.liacs.nl/%7Ejeggermo/">Jeroen
-        Eggermont</a>, who, among other things, did a lot of work on GP,
-        INRIA Dolphin Team, <a
-        href="mailto:okoenig@users.sourceforge.net">Olivier König</a>, who did a
+        <p> The developement team has then been reinforced by
+        Maarten Keijzer (the C++
+        wizard), and Marc Schoenauer.
+        Later came Jeroen
+        Eggermont, who, among other things, did a lot of work on GP,
+        INRIA Dolphin Team, Olivier K&ouml;nig, who did a
         lot of useful additions and cleaning of the code and <a
-        href="http://www.jochen-kuepper.de">Jochen Küpper</a>, working on
+        href="https://www.jochen-kuepper.de">Jochen K&uuml;pper</a>, working on
         infrastructure maintenance. </p>
 
       </td>
@@ -81,7 +76,7 @@ background: #00309c;
         </ul>
 
         <p> If you have tested EO on a system not listed here, please <a
-        href="mailto:eodev-main@lists.sourceforge.net?subject=test-report">let
+        href="https://github.com/nojhan/paradiseo/issues">let
         us know</a>. </p>
 
         <p> If you are working on a system with an older C++ compiler there
@@ -98,26 +93,11 @@ background: #00309c;
 
         <p>The tutorial demonstrates that writing an evolutionary algorithm
         evolving your own structures is now <em>easy</em>, using ready-to-use
-        template files. Although the tutorial has not been upgraded for some
-        time now and refers to version 0.9.2 of EO, it nevertheless remains the
-        best way to dive into EO. You can start by trying it on-line at <a
-        href="http://www.lri.fr/%7Emarc/EO/eo/tutorial/html/eoTutorial.html">LRI</a>
-        or <a
-        href="http://eodev.sourceforge.net/eo/tutorial/html/eoTutorial.html">SourceForge</a>,
-        before <a href="http://www.lri.fr/%7Emarc/EO/">downloading it</a>. The
-        tutorial is also included in the <a
-        href="http://sourceforge.net/project/showfiles.php?group_id=9775">released
-        sources</a>. </p>
+        template files. The tutorial is included in the source tree at
+        <a href="https://github.com/nojhan/paradiseo/tree/master/eo/tutorial">eo/tutorial/</a>. </p>
 
-        <p>The latest <a
-        href="http://eodev.sourceforge.net/eo/tutorial/html/eoTutorial.html">tutorial
-        release</a>
-	</p>
-
-        <p>The complete code is also well documented and you can look at the
-        generated <a
-        href="http://eodev.sourceforge.net/eo/doc/html/index.html">interface
-        documentation</a>. </p>
+        <p>The complete code is also well documented and you can generate the
+        API documentation locally with <code>make doc-eo</code>. </p>
 
         <p>The easiest way to create a complete new EO-project, even for new
         genomes, is to use the script provided in tutorial/Templates/; see
@@ -132,17 +112,9 @@ background: #00309c;
       </td>
       <td bgcolor="#ffcc99">
         
-        <p> A functional and "philosophical" overview of EO was presented at <a
-        href="http://www.cmap.polytechnique.fr/%7Eea01/">EA'01 conference</a>.
-        You can download <a
-        href="http://eodev.sourceforge.net/eo/doc/EO_EA2001.pdf">the paper</a>
-        or <a href="http://eodev.sourceforge.net/eo/doc/LeCreusot.pdf">the
-        slides</a>. </p>
-        
-        <p> A <a href="http://geneura.ugr.es/~jmerelo/GAPPT/index.html"
-        target="_blank">PowerPoint presentation</a> shows the EO philosophy, and
-        it includes a Visual Basic macro for evolving objects in Visual Basic
-        for Applications. </p>
+        <p> A functional and "philosophical" overview of EO was presented at EA'01 conference.
+        You can find the paper (<code>EO_EA2001.pdf</code>)
+        and the slides (<code>LeCreusot.pdf</code>) in the <code>eo/doc/</code> directory. </p>
         
         <p>You can also look a the <a href="publications.html">list of
         publications</a> that used EO to solve real problems. </p>
@@ -155,18 +127,14 @@ background: #00309c;
       </td>
       <td bgcolor="#ffcc99">
 
-        <p> The current release is <a
-        href="http://sourceforge.net/project/showfiles.php?group_id=9775">EO 1.0</a>.
-        It supports any Standard-compliant C++ compiler. </p>
-        
-        <p> You can obtain the latest version directly via <a
-        href="http://sourceforge.net/cvs/?group_id=9775">cvs</a> or download a
-        daily snapshot from <a
-        href="http://www.lri.fr/%7Emarc/EO/snapshot">LRI</a>. </p>
-        
-        <p> All releases can be obtained from the SourceForge <a
-        href="http://sourceforge.net/project/showfiles.php?group_id=9775">download
-        area</a>. </p>
+        <p> EO is now part of <a
+        href="https://github.com/nojhan/paradiseo">ParadisEO</a>.
+        You can obtain the latest version via Git:
+        <code>git clone https://github.com/nojhan/paradiseo.git</code> </p>
+
+        <p> Releases can be obtained from the <a
+        href="https://github.com/nojhan/paradiseo/releases">GitHub releases
+        page</a>. </p>
         
       </td>
     </tr>
@@ -176,11 +144,9 @@ background: #00309c;
       </td>
       <td bgcolor="#ffcc99">
 
-        We would like EO to be an open development effort; that is why we have
-        created mailing lists to discuss future developments, solve technical
-        problems, announce releases, publish patches, and discuss evolutionary
-        computation in general. Browse the archives or join the <a
-        href="http://sourceforge.net/mail/?group_id=9775">EO mailing lists</a>.
+        For questions, bug reports, or contributions, please use the
+        <a href="https://github.com/nojhan/paradiseo/issues">GitHub issue tracker</a>
+        or the <a href="https://app.element.io/#/room/#paradiseo:matrix.org">Matrix chatroom</a>.
         
       </td>
     </tr>
@@ -190,23 +156,11 @@ background: #00309c;
       </td>
       <td bgcolor="#ffcc99">
         
-        <p>The following resources are available, thanks to sourceforge</p>
+        <p>EO is now developed as part of ParadisEO on GitHub:</p>
         <ul>
-          <li> <a href="http://sourceforge.net/project/?group_id=9775">EO
-          SourceForge Project Page</a></li>
-          <li><a href="http://eodev.sourceforge.net/eo/doc/html/index.html">EO
-          automatic documentation page at SF</a><br>
-          </li>
-          <li><a href="http://eodev.sourceforge.net/eo/tutorial/html/eoTutorial.html">EO
-          tutorial page at SF</a><br>
-          </li>
-          <li> <a href="https://sourceforge.net/project/showfiles.php?group_id=9775">Releases</a></li>
-          <li> <a href="http://sourceforge.net/mail/?group_id=9775">Mailing Lists</a></li>
-          <li> <a href="http://sourceforge.net/forum/?group_id=9775">Message Forums</a></li>
-          <li> <a href="http://sourceforge.net/bugs/?group_id=9775">Bug Submission and Tracking</a></li>
-          <li> <a href="http://sourceforge.net/support/?group_id=9775">Technical Support</a></li>
-          <li> <a href="http://sourceforge.net/patch/?group_id=9775">Patch Submission</a></li>
-          <li> <a href="http://sourceforge.net/cvs/?group_id=9775">CVS repository</a></li>
+          <li> <a href="https://github.com/nojhan/paradiseo">ParadisEO GitHub repository</a></li>
+          <li> <a href="https://github.com/nojhan/paradiseo/issues">Issue tracker</a></li>
+          <li> <a href="https://github.com/nojhan/paradiseo/releases">Releases</a></li>
         </ul>
       </td>
     </tr>
@@ -226,15 +180,10 @@ background: #00309c;
       </td>
       <td bgcolor="#ffcc99">
 
-        <p> <a href="http://paradiseo.gforge.inria.fr"
-        target="_blank">ParadisEO</a> provides EO extensions for
+        <p> <a href="https://nojhan.github.io/paradiseo/">ParadisEO</a> provides EO extensions for
         the flexible design of <b>single solution-based metaheuristics</b>,
 		metaheuristics for <b>multi objective optimization</b> as well as <b>hybrid, parallel and distributed
 		metaheuristics</b>.</p>
-
-        <p> <a href="http://geneura.ugr.es/~jmerelo/DegaX/"
-        target="_blank">DegaX</a> is an ActiveX control which embeds EO 0.8.4.
-        </p>
 
       </td>
     </tr>
@@ -245,30 +194,20 @@ background: #00309c;
       <td bgcolor="#ffcc99">
 
         <ul>
-          <li><a href="http://www.aip.de/~ast/EvolCompFAQ" target="_blank">The
-          Hitch-Hiker's Guide to Evolutionary Computation</a>, FAQ for 
-          <a href="news:comp.ai.genetic">comp.ai.genetic</a>.</li>
-          <li><a href="http://en.wikipedia.org/wiki/Evolutionary_algorithm" target="_blank">Wikipedia</a>
+          <li><a href="https://en.wikipedia.org/wiki/Evolutionary_algorithm" target="_blank">Wikipedia</a>
           on Evolutionary algorithms.</li>
-          <li>Charles Darwin: <a href="http://en.wikipedia.org/wiki/The_Origin_of_Species" target="_blank">The
+          <li>Charles Darwin: <a href="https://en.wikipedia.org/wiki/The_Origin_of_Species" target="_blank">The
           Origin of Species</a>.</li>
-          <li>Nikolaus Hansen: <a
-          href="http://www.bionik.tu-berlin.de/user/niko/cec2005.html" target="_blank">Comparison
-          of Evolutionary Algorithms on a Benchmark Function Set</a>.</li>
+          <li><a href="https://cma-es.github.io/" target="_blank">CMA-ES</a>:
+          Covariance Matrix Adaptation Evolution Strategy.</li>
         </ul>
       </td>
     </tr>
   </tbody>
 </table>
 
-<center> <p> Hosted by:<br/><a href="http://sourceforge.net/"><img alt="SF logo"
-src="http://eodev.sourceforge.net/eo/doc/sflogo-hammer1.jpg"></a> </p> </center>
-
-<p> <a href="http://validator.w3.org/check?uri=referer"> <img
-src="http://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Transitional"
-height="31" width="88"></a> <br/> Please send comments on this webpage to the <a
-href="mailto:eodev-main@lists.sourceforge.net?subject=webpage">EO mailing
-list</a>. </p>
+<p>Please report issues on the <a
+href="https://github.com/nojhan/paradiseo/issues">GitHub issue tracker</a>. </p>
 
 </body>
 </html>

--- a/eo/doc/publications.html
+++ b/eo/doc/publications.html
@@ -50,7 +50,7 @@
     <center>
       <p>
         Hosted by:<br/><a href="http://sourceforge.net/"><img alt="SF logo"
-        src="http://eodev.sourceforge.net/eo/doc/sflogo-hammer1.jpg"></a>
+        src="sflogo-hammer1.jpg"></a>
       </p>
     </center>
     <p>

--- a/eo/src/eoDualFitness.h
+++ b/eo/src/eoDualFitness.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalCmd.h
+++ b/eo/src/eoEvalCmd.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalCounterThrowException.h
+++ b/eo/src/eoEvalCounterThrowException.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalNamedPipe.h
+++ b/eo/src/eoEvalNamedPipe.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalNanThrowException.h
+++ b/eo/src/eoEvalNanThrowException.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalTimeThrowException.h
+++ b/eo/src/eoEvalTimeThrowException.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoEvalUserTimeThrowException.h
+++ b/eo/src/eoEvalUserTimeThrowException.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoExceptions.h
+++ b/eo/src/eoExceptions.h
@@ -15,7 +15,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/eoInvertedContinue.h
+++ b/eo/src/eoInvertedContinue.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _eoInvertedContinue_h

--- a/eo/src/eoPartiallyMappedXover.h
+++ b/eo/src/eoPartiallyMappedXover.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 #ifndef eoPartiallyMappedXover__h
 #define eoPartiallyMappedXover__h

--- a/eo/src/es/eoEsChromInit.h
+++ b/eo/src/es/eoEsChromInit.h
@@ -14,7 +14,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mak@dhi.dk

--- a/eo/src/es/eoEsSimple.h
+++ b/eo/src/es/eoEsSimple.h
@@ -13,7 +13,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mak@dhi.dk

--- a/eo/src/es/eoEsStdev.h
+++ b/eo/src/es/eoEsStdev.h
@@ -13,7 +13,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mak@dhi.dk

--- a/eo/src/es/make_genotype_es.cpp
+++ b/eo/src/es/make_genotype_es.cpp
@@ -13,7 +13,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mkeijzer@dhi.dk

--- a/eo/src/es/make_genotype_real.h
+++ b/eo/src/es/make_genotype_real.h
@@ -14,7 +14,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mkeijzer@dhi.dk

--- a/eo/src/es/make_op_es.h
+++ b/eo/src/es/make_op_es.h
@@ -13,7 +13,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
          todos@geneura.ugr.es, http://geneura.ugr.es
          Marc.Schoenauer@polytechnique.fr
          mkeijzer@dhi.dk

--- a/eo/src/mpi/eoMpi.cpp
+++ b/eo/src/mpi/eoMpi.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoMpi.h
+++ b/eo/src/mpi/eoMpi.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoMpiAssignmentAlgorithm.cpp
+++ b/eo/src/mpi/eoMpiAssignmentAlgorithm.cpp
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoMpiAssignmentAlgorithm.h
+++ b/eo/src/mpi/eoMpiAssignmentAlgorithm.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoMpiNode.cpp
+++ b/eo/src/mpi/eoMpiNode.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoMpiNode.h
+++ b/eo/src/mpi/eoMpiNode.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoParallelApply.h
+++ b/eo/src/mpi/eoParallelApply.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/eoTerminateJob.h
+++ b/eo/src/mpi/eoTerminateJob.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/implMpi.cpp
+++ b/eo/src/mpi/implMpi.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/mpi/implMpi.h
+++ b/eo/src/mpi/implMpi.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Entity.h
+++ b/eo/src/serial/Entity.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Parser.cpp
+++ b/eo/src/serial/Parser.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Parser.h
+++ b/eo/src/serial/Parser.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialArray.cpp
+++ b/eo/src/serial/SerialArray.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialArray.h
+++ b/eo/src/serial/SerialArray.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialObject.cpp
+++ b/eo/src/serial/SerialObject.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialObject.h
+++ b/eo/src/serial/SerialObject.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialString.cpp
+++ b/eo/src/serial/SerialString.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/SerialString.h
+++ b/eo/src/serial/SerialString.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Serializable.h
+++ b/eo/src/serial/Serializable.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Traits.h
+++ b/eo/src/serial/Traits.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/Utils.h
+++ b/eo/src/serial/Utils.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/serial/eoSerial.h
+++ b/eo/src/serial/eoSerial.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/src/utils/eoFeasibleRatioStat.h
+++ b/eo/src/utils/eoFeasibleRatioStat.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/utils/eoHowMany.h
+++ b/eo/src/utils/eoHowMany.h
@@ -21,7 +21,7 @@
    License along with this library; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 */
 //-----------------------------------------------------------------------------

--- a/eo/src/utils/eoLogMessage.h
+++ b/eo/src/utils/eoLogMessage.h
@@ -13,7 +13,7 @@
     with this library; if not, write to the Free Software Foundation, Inc., 59
     Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
      Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/utils/eoLogMonitor.h
+++ b/eo/src/utils/eoLogMonitor.h
@@ -15,7 +15,7 @@
     with this library; if not, write to the Free Software Foundation, Inc., 59
     Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
      Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/utils/eoLogger.cpp
+++ b/eo/src/utils/eoLogger.cpp
@@ -18,7 +18,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/utils/eoLogger.h
+++ b/eo/src/utils/eoLogger.h
@@ -17,7 +17,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Johann Dréo <johann.dreo@thalesgroup.com>

--- a/eo/src/utils/eoOStreamMonitor.h
+++ b/eo/src/utils/eoOStreamMonitor.h
@@ -15,7 +15,7 @@
     with this library; if not, write to the Free Software Foundation, Inc., 59
     Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
      todos@geneura.ugr.es

--- a/eo/src/utils/eoParallel.cpp
+++ b/eo/src/utils/eoParallel.cpp
@@ -18,7 +18,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Caner Candan <caner.candan@thalesgroup.com>

--- a/eo/src/utils/eoParallel.h
+++ b/eo/src/utils/eoParallel.h
@@ -17,7 +17,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Caner Candan <caner.candan@thalesgroup.com>

--- a/eo/src/utils/eoParser.cpp
+++ b/eo/src/utils/eoParser.cpp
@@ -18,7 +18,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 Authors:
     todos@geneura.ugr.es, http://geneura.ugr.es
     Marc.Schoenauer@polytechnique.fr

--- a/eo/src/utils/eoParser.h
+++ b/eo/src/utils/eoParser.h
@@ -13,7 +13,7 @@ You should have received a copy of the GNU Lesser General Public License along
 with this library; if not, write to the Free Software Foundation, Inc., 59
 Temple Place, Suite 330, Boston, MA 02111-1307 USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 Authors:
     todos@geneura.ugr.es, http://geneura.ugr.es
     Marc.Schoenauer@polytechnique.fr

--- a/eo/src/utils/eoSignal.cpp
+++ b/eo/src/utils/eoSignal.cpp
@@ -15,7 +15,7 @@
    License along with this library; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-   Contact: http://eodev.sourceforge.net
+   Contact: https://nojhan.github.io/paradiseo
 
    Autors: todos@geneura.ugr.es, http://geneura.ugr.es
 	   Marc.Schoenauer@polytechnique.fr

--- a/eo/src/utils/eoSignal.h
+++ b/eo/src/utils/eoSignal.h
@@ -15,7 +15,7 @@
    License along with this library; if not, write to the Free Software
    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-   Contact: http://eodev.sourceforge.net
+   Contact: https://nojhan.github.io/paradiseo
 
    Authors: todos@geneura.ugr.es, http://geneura.ugr.es
 	    Marc.Schoenauer@polytechnique.fr

--- a/eo/src/utils/eoStat.h
+++ b/eo/src/utils/eoStat.h
@@ -19,7 +19,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
     Authors:
         todos@geneura.ugr.es, http://geneura.ugr.es

--- a/eo/src/utils/eoStdoutMonitor.h
+++ b/eo/src/utils/eoStdoutMonitor.h
@@ -18,7 +18,7 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
      todos@geneura.ugr.es

--- a/eo/src/utils/eoTimer.h
+++ b/eo/src/utils/eoTimer.h
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/test/mpi/t-mpi-eval.cpp
+++ b/eo/test/mpi/t-mpi-eval.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/test/mpi/t-mpi-multipleRoles.cpp
+++ b/eo/test/mpi/t-mpi-multipleRoles.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/test/mpi/t-mpi-parallelApply.cpp
+++ b/eo/test/mpi/t-mpi-parallelApply.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/test/mpi/t-mpi-wrapper.cpp
+++ b/eo/test/mpi/t-mpi-wrapper.cpp
@@ -14,7 +14,7 @@
     You should have received a copy of the GNU Lesser General Public
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Benjamin Bouvier <benjamin.bouvier@gmail.com>

--- a/eo/test/t-openmp.cpp
+++ b/eo/test/t-openmp.cpp
@@ -17,7 +17,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
 Caner Candan <caner.candan@thalesgroup.com>

--- a/eo/test/t-openmp.py
+++ b/eo/test/t-openmp.py
@@ -17,7 +17,7 @@
 #    License along with this library; if not, write to the Free Software
 #    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 #
-# Contact: http://eodev.sourceforge.net
+# Contact: https://nojhan.github.io/paradiseo
 #
 # Authors:
 # Caner Candan <caner.candan@thalesgroup.com>

--- a/eo/tutorial/html/eoTutorial.html
+++ b/eo/tutorial/html/eoTutorial.html
@@ -31,8 +31,7 @@ but go to the <font color="#FF6666"><b>test</b></font> directory, type
 <font color="#FF6600"><b>make t-eoCMAES</b></font> and use the resulting <font
 color="#FF6666"><b>t-eoCMAES</b></font>. But as of today, 
 the latest algorithms (and comparative results) 
-are better found on <a href="http://www.bionik.tu-berlin.de/user/niko/">Nikolaus Hansen Web page</a>
-and on his <a href="http://www.bionik.tu-berlin.de/user/niko/cec2005.html">"Comparison of Evolutionary Algorithms on a Benchmark Function Set" page</a>).<br>
+are better found on the <a href="https://cma-es.github.io/">CMA-ES project page</a>.<br>
 <br>
 <br>
 
@@ -92,8 +91,8 @@ html-ized code are not yet updated - time is missing
 <center><font color="#FF0000">May 2002</font></center>
 <li>
 <center>
-<font color="#000000">Thanks to <a href="mailto:paradiseo-help@lists.gforge.inria.fr">S&eacute;bastien
-Cahon</a> (LIFL, Lille)</font></center>
+<font color="#000000">Thanks to S&eacute;bastien
+Cahon (LIFL, Lille)</font></center>
 
 </ul>
 <hr WIDTH="100%">
@@ -142,14 +141,12 @@ and to quickly reach some specific part of the code.</li>
 diagram of the class, and you'll learn a lot by simply looking at it.
 <li>
 For those who wish to get deeper in STL (Standard Template Library), you
-might visit the well documented <a href="http://www.sgi.com/Technology/STL/">SGI
-STL Web site</a>. But don't forget you'll find the very basic minimum in
+might visit <a href="https://en.cppreference.com/w/cpp/container.html">cppreference.com</a>. But don't forget you'll find the very basic minimum in
 EO <a href="eoProgramming.html#STL">programming hints</a>.</li>
 
 <li>
-And, last but not least, we assume you know approximately that an Evolutionary
-Algorithm looks like this, but otherwise you can try this <a href="eoIntroEA.html">very
-brief introduction</a> (not written yet, Jan. 2001, sorry).</li>
+And, last but not least, we assume you know approximately what an Evolutionary
+Algorithm looks like.</li>
 </ul>
 
 <p><br>
@@ -233,8 +230,8 @@ rather than when you have something urgent to code :-)</li>
 
 <hr WIDTH="100%"><a NAME="install"></a><b><font color="#000099"><font size=+1>Before
 you start</font></font></b>
-<p>You should of course have downloaded and installed the whole <a href="http://www.sourceforge.net/projects/eodev">EO
-library</a> (how did you get this file if not???). 
+<p>You should of course have downloaded and installed the whole <a href="https://github.com/nojhan/paradiseo">ParadisEO
+framework</a> (how did you get this file if not???). 
 If you are using a recent version of EO (0.9.3+), all tutorial Lessons 
 should have been compiled when installing the library, and you can now 
 proceed with <a href="eoLesson1.html">Lesson1</a>. <br>

--- a/mo/doc/index.h
+++ b/mo/doc/index.h
@@ -6,12 +6,13 @@ ParadisEO-MO is a white-box object-oriented generic framework dedicated to the f
 
 @section tutorials Tutorials
 
-Tutorials for ParadisEO-MO are available in the "Tutorials section" of the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+Tutorials for ParadisEO-MO are available in the mo/tutorial/ directory. See also the
+<a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 @section Design
 
 For an introduction to the design of ParadisEO-MO,
-you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+you can look at the <a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 @section LICENSE
 
@@ -39,14 +40,14 @@ you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
 
 */
 
 /** @page webpages Related webpages
 
-- ParadisEO <a href="http://paradiseo.gforge.inria.fr">homepage</a>
-- INRIA GForge <a href="http://gforge.inria.fr/projects/paradiseo/">project page</a>
+- ParadisEO <a href="https://nojhan.github.io/paradiseo/">homepage</a>
+- GitHub <a href="https://github.com/nojhan/paradiseo">project page</a>
 - <a href="../../README">README</a>
 */

--- a/mo/doc/mo.doxyfile.cmake
+++ b/mo/doc/mo.doxyfile.cmake
@@ -1295,7 +1295,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=http://eodev.sourceforge.net/eo/doc/html
+TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=https://nojhan.github.io/paradiseo/eo/doc/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.

--- a/mo/src/acceptCrit/moAcceptanceCriterion.h
+++ b/mo/src/acceptCrit/moAcceptanceCriterion.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moAcceptanceCriterion_h

--- a/mo/src/acceptCrit/moAlwaysAcceptCrit.h
+++ b/mo/src/acceptCrit/moAlwaysAcceptCrit.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moAlwaysAcceptCrit_h

--- a/mo/src/acceptCrit/moBetterAcceptCrit.h
+++ b/mo/src/acceptCrit/moBetterAcceptCrit.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBetterAcceptCrit_h

--- a/mo/src/algo/eoDummyMonOp.h
+++ b/mo/src/algo/eoDummyMonOp.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moDummyMonOp_h

--- a/mo/src/algo/moDummyLS.h
+++ b/mo/src/algo/moDummyLS.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyLS_h

--- a/mo/src/algo/moFirstImprHC.h
+++ b/mo/src/algo/moFirstImprHC.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moFirstImprHC_h

--- a/mo/src/algo/moILS.h
+++ b/mo/src/algo/moILS.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moILS_h

--- a/mo/src/algo/moLocalSearch.h
+++ b/mo/src/algo/moLocalSearch.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moLocalSearch_h

--- a/mo/src/algo/moMetropolisHasting.h
+++ b/mo/src/algo/moMetropolisHasting.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moMetropolisHasting_h

--- a/mo/src/algo/moNeutralHC.h
+++ b/mo/src/algo/moNeutralHC.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeutralHC_h

--- a/mo/src/algo/moRandomBestHC.h
+++ b/mo/src/algo/moRandomBestHC.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomBestHC_h

--- a/mo/src/algo/moRandomNeutralWalk.h
+++ b/mo/src/algo/moRandomNeutralWalk.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomNeutralWalk_h

--- a/mo/src/algo/moRandomSearch.h
+++ b/mo/src/algo/moRandomSearch.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomSearch_h

--- a/mo/src/algo/moRandomWalk.h
+++ b/mo/src/algo/moRandomWalk.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomWalk_h

--- a/mo/src/algo/moSA.h
+++ b/mo/src/algo/moSA.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSA_h

--- a/mo/src/algo/moSimpleHC.h
+++ b/mo/src/algo/moSimpleHC.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSimpleHC_h

--- a/mo/src/algo/moTS.h
+++ b/mo/src/algo/moTS.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moTS_h

--- a/mo/src/algo/moVNS.h
+++ b/mo/src/algo/moVNS.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moVNS_h

--- a/mo/src/comparator/moComparator.h
+++ b/mo/src/comparator/moComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moComparator_h

--- a/mo/src/comparator/moEqualNeighborComparator.h
+++ b/mo/src/comparator/moEqualNeighborComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moEqualNeighborComparator_h

--- a/mo/src/comparator/moEqualSolComparator.h
+++ b/mo/src/comparator/moEqualSolComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moEqualSolComparator_h

--- a/mo/src/comparator/moEqualSolNeighborComparator.h
+++ b/mo/src/comparator/moEqualSolNeighborComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moEqualSolNeighborComparator_h

--- a/mo/src/comparator/moNeighborComparator.h
+++ b/mo/src/comparator/moNeighborComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeighborComparator_h

--- a/mo/src/comparator/moSolComparator.h
+++ b/mo/src/comparator/moSolComparator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSolComparator_h

--- a/mo/src/comparator/moSolNeighborComparator.h
+++ b/mo/src/comparator/moSolNeighborComparator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSolNeighborComparator_h

--- a/mo/src/continuator/moAverageFitnessNeighborStat.h
+++ b/mo/src/continuator/moAverageFitnessNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moAverageFitnessNeighborStat_h

--- a/mo/src/continuator/moBestFitnessStat.h
+++ b/mo/src/continuator/moBestFitnessStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moBestFitnessStat_h

--- a/mo/src/continuator/moBestNoImproveContinuator.h
+++ b/mo/src/continuator/moBestNoImproveContinuator.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBestNoImproveContinuator_h

--- a/mo/src/continuator/moBestSoFarStat.h
+++ b/mo/src/continuator/moBestSoFarStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moBestSoFarStat_h

--- a/mo/src/continuator/moBooleanStat.h
+++ b/mo/src/continuator/moBooleanStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moBooleanStat_h

--- a/mo/src/continuator/moCheckpoint.h
+++ b/mo/src/continuator/moCheckpoint.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moCheckpoint_h

--- a/mo/src/continuator/moCombinedContinuator.h
+++ b/mo/src/continuator/moCombinedContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moCombinedContinuator_h

--- a/mo/src/continuator/moContinuator.h
+++ b/mo/src/continuator/moContinuator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moContinuator_h

--- a/mo/src/continuator/moCounterMonitorSaver.h
+++ b/mo/src/continuator/moCounterMonitorSaver.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moCounterMonitorSaver_h

--- a/mo/src/continuator/moCounterStat.h
+++ b/mo/src/continuator/moCounterStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moCounterStat_h

--- a/mo/src/continuator/moDistanceStat.h
+++ b/mo/src/continuator/moDistanceStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moDistanceStat_h

--- a/mo/src/continuator/moEvalsContinuator.h
+++ b/mo/src/continuator/moEvalsContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moEvalsContinuator_h

--- a/mo/src/continuator/moFitContinuator.h
+++ b/mo/src/continuator/moFitContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moFitContinuator_h

--- a/mo/src/continuator/moFitnessStat.h
+++ b/mo/src/continuator/moFitnessStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moFitnessStat_h

--- a/mo/src/continuator/moFullEvalContinuator.h
+++ b/mo/src/continuator/moFullEvalContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moFullEvalContinuator_h

--- a/mo/src/continuator/moIterContinuator.h
+++ b/mo/src/continuator/moIterContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moIterContinuator_h

--- a/mo/src/continuator/moMaxNeighborStat.h
+++ b/mo/src/continuator/moMaxNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMaxNeighborStat_h

--- a/mo/src/continuator/moMedianNeighborStat.h
+++ b/mo/src/continuator/moMedianNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMedianNeighborStat_h

--- a/mo/src/continuator/moMinNeighborStat.h
+++ b/mo/src/continuator/moMinNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMinNeighborStat_h

--- a/mo/src/continuator/moMinusOneCounterStat.h
+++ b/mo/src/continuator/moMinusOneCounterStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMinusOneCounterStat_h

--- a/mo/src/continuator/moNbInfNeighborStat.h
+++ b/mo/src/continuator/moNbInfNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNbInfNeighborStat_h

--- a/mo/src/continuator/moNbSupNeighborStat.h
+++ b/mo/src/continuator/moNbSupNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNbSupNeighborStat_h

--- a/mo/src/continuator/moNeighborBestStat.h
+++ b/mo/src/continuator/moNeighborBestStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeighborBestStat_h

--- a/mo/src/continuator/moNeighborEvalContinuator.h
+++ b/mo/src/continuator/moNeighborEvalContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeighborEvalContinuator_h

--- a/mo/src/continuator/moNeighborFitnessStat.h
+++ b/mo/src/continuator/moNeighborFitnessStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeighborFitnessStat_h

--- a/mo/src/continuator/moNeighborhoodStat.h
+++ b/mo/src/continuator/moNeighborhoodStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeighborhoodStat_h

--- a/mo/src/continuator/moNeutralDegreeNeighborStat.h
+++ b/mo/src/continuator/moNeutralDegreeNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeutralDegreeNeighborStat_h

--- a/mo/src/continuator/moQ1NeighborStat.h
+++ b/mo/src/continuator/moQ1NeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moQ1NeighborStat_h

--- a/mo/src/continuator/moQ3NeighborStat.h
+++ b/mo/src/continuator/moQ3NeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moQ3NeighborStat_h

--- a/mo/src/continuator/moQuartilesNeighborStat.h
+++ b/mo/src/continuator/moQuartilesNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moQuartilesNeighborStat_h

--- a/mo/src/continuator/moSecondMomentNeighborStat.h
+++ b/mo/src/continuator/moSecondMomentNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moSecondMomentNeighborStat_h

--- a/mo/src/continuator/moSizeNeighborStat.h
+++ b/mo/src/continuator/moSizeNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moSizeNeighborStat_h

--- a/mo/src/continuator/moSolutionStat.h
+++ b/mo/src/continuator/moSolutionStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moSolutionStat_h

--- a/mo/src/continuator/moStat.h
+++ b/mo/src/continuator/moStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moStat_h

--- a/mo/src/continuator/moStatBase.h
+++ b/mo/src/continuator/moStatBase.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moStatBase_h

--- a/mo/src/continuator/moStatFromStat.h
+++ b/mo/src/continuator/moStatFromStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moStatFromStat_h

--- a/mo/src/continuator/moStdFitnessNeighborStat.h
+++ b/mo/src/continuator/moStdFitnessNeighborStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moStdFitnessNeighborStat_h

--- a/mo/src/continuator/moTimeContinuator.h
+++ b/mo/src/continuator/moTimeContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moTimeContinuator_h

--- a/mo/src/continuator/moTrueContinuator.h
+++ b/mo/src/continuator/moTrueContinuator.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moTrueContinuator_h

--- a/mo/src/continuator/moUnsignedStat.h
+++ b/mo/src/continuator/moUnsignedStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moUnsignedStat_h

--- a/mo/src/continuator/moUpdater.h
+++ b/mo/src/continuator/moUpdater.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moUpdater_h

--- a/mo/src/continuator/moValueParamContinuator.h
+++ b/mo/src/continuator/moValueParamContinuator.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moValueParamContinuator_h

--- a/mo/src/continuator/moValueStat.h
+++ b/mo/src/continuator/moValueStat.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moValueStat_h

--- a/mo/src/continuator/moVectorMonitor.h
+++ b/mo/src/continuator/moVectorMonitor.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef moVectorMonitor_h

--- a/mo/src/coolingSchedule/moCoolingSchedule.h
+++ b/mo/src/coolingSchedule/moCoolingSchedule.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moCoolingSchedule_h

--- a/mo/src/coolingSchedule/moDynSpanCoolingSchedule.h
+++ b/mo/src/coolingSchedule/moDynSpanCoolingSchedule.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDynSpanCoolingSchedule_h

--- a/mo/src/coolingSchedule/moSimpleCoolingSchedule.h
+++ b/mo/src/coolingSchedule/moSimpleCoolingSchedule.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSimpleCoolingSchedule_h

--- a/mo/src/eval/moDoubleIncrEvaluation.h
+++ b/mo/src/eval/moDoubleIncrEvaluation.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moDoubleIncrEvaluation_H

--- a/mo/src/eval/moDoubleIncrNeighborhoodEval.h
+++ b/mo/src/eval/moDoubleIncrNeighborhoodEval.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moDoubleIncrNeighborhoodEval_H

--- a/mo/src/eval/moDummyEval.h
+++ b/mo/src/eval/moDummyEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyEval_h

--- a/mo/src/eval/moEval.h
+++ b/mo/src/eval/moEval.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moEval_H

--- a/mo/src/eval/moEvalCounter.h
+++ b/mo/src/eval/moEvalCounter.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moEvalCounter_h

--- a/mo/src/eval/moFullEvalByCopy.h
+++ b/mo/src/eval/moFullEvalByCopy.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moFullEvalByCopy_H

--- a/mo/src/eval/moFullEvalByModif.h
+++ b/mo/src/eval/moFullEvalByModif.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moFullEvalByModif_H

--- a/mo/src/eval/moNeighborhoodEvaluation.h
+++ b/mo/src/eval/moNeighborhoodEvaluation.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeighborhoodEvaluation_H

--- a/mo/src/explorer/moDummyExplorer.h
+++ b/mo/src/explorer/moDummyExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyExplorer_h

--- a/mo/src/explorer/moFirstImprHCexplorer.h
+++ b/mo/src/explorer/moFirstImprHCexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moFirstImprHCexplorer_h

--- a/mo/src/explorer/moILSexplorer.h
+++ b/mo/src/explorer/moILSexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moILSexplorer_h

--- a/mo/src/explorer/moMetropolisHastingExplorer.h
+++ b/mo/src/explorer/moMetropolisHastingExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moMetropolisHastingExplorer_h

--- a/mo/src/explorer/moNeighborhoodExplorer.h
+++ b/mo/src/explorer/moNeighborhoodExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _neighborhoodExplorer_h

--- a/mo/src/explorer/moNeutralHCexplorer.h
+++ b/mo/src/explorer/moNeutralHCexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeutralHCexplorer_h

--- a/mo/src/explorer/moRandomBestHCexplorer.h
+++ b/mo/src/explorer/moRandomBestHCexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomBestHCexplorer_h

--- a/mo/src/explorer/moRandomNeutralWalkExplorer.h
+++ b/mo/src/explorer/moRandomNeutralWalkExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomNeutralWalkexplorer_h

--- a/mo/src/explorer/moRandomSearchExplorer.h
+++ b/mo/src/explorer/moRandomSearchExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomSearchexplorer_h

--- a/mo/src/explorer/moRandomWalkExplorer.h
+++ b/mo/src/explorer/moRandomWalkExplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRandomWalkexplorer_h

--- a/mo/src/explorer/moSAexplorer.h
+++ b/mo/src/explorer/moSAexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSAexplorer_h

--- a/mo/src/explorer/moSimpleHCexplorer.h
+++ b/mo/src/explorer/moSimpleHCexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSimpleHCexplorer_h

--- a/mo/src/explorer/moTSexplorer.h
+++ b/mo/src/explorer/moTSexplorer.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 #ifndef _moTSexplorer_h
 #define _moTSexplorer_h

--- a/mo/src/explorer/moVNSexplorer.h
+++ b/mo/src/explorer/moVNSexplorer.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moVNSexplorer_h

--- a/mo/src/memory/moAspiration.h
+++ b/mo/src/memory/moAspiration.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 

--- a/mo/src/memory/moBestImprAspiration.h
+++ b/mo/src/memory/moBestImprAspiration.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 

--- a/mo/src/memory/moCountMoveMemory.h
+++ b/mo/src/memory/moCountMoveMemory.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moCountMoveMemory_h

--- a/mo/src/memory/moDiversification.h
+++ b/mo/src/memory/moDiversification.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDiversification_h

--- a/mo/src/memory/moDummyDiversification.h
+++ b/mo/src/memory/moDummyDiversification.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyDiversification_h

--- a/mo/src/memory/moDummyIntensification.h
+++ b/mo/src/memory/moDummyIntensification.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyIntensification_h

--- a/mo/src/memory/moDummyMemory.h
+++ b/mo/src/memory/moDummyMemory.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyMemory_h

--- a/mo/src/memory/moIndexedVectorTabuList.h
+++ b/mo/src/memory/moIndexedVectorTabuList.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moIndexedVectorTabuList_h

--- a/mo/src/memory/moIntensification.h
+++ b/mo/src/memory/moIntensification.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moIntensification_h

--- a/mo/src/memory/moMonOpDiversification.h
+++ b/mo/src/memory/moMonOpDiversification.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moMonOpDiversification_h

--- a/mo/src/memory/moNeighborVectorTabuList.h
+++ b/mo/src/memory/moNeighborVectorTabuList.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeighborVectorTabuList_h

--- a/mo/src/memory/moRndIndexedVectorTabuList.h
+++ b/mo/src/memory/moRndIndexedVectorTabuList.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRndIndexedVectorTabuList_h

--- a/mo/src/memory/moSolVectorTabuList.h
+++ b/mo/src/memory/moSolVectorTabuList.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSolVectorTabuList_h

--- a/mo/src/memory/moTabuList.h
+++ b/mo/src/memory/moTabuList.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moTabuList_h

--- a/mo/src/mo
+++ b/mo/src/mo
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef __newmo

--- a/mo/src/mo.h
+++ b/mo/src/mo.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _newmo_h

--- a/mo/src/neighborhood/moBackableNeighbor.h
+++ b/mo/src/neighborhood/moBackableNeighbor.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _BackableNeighbor_h

--- a/mo/src/neighborhood/moBackwardVectorVNSelection.h
+++ b/mo/src/neighborhood/moBackwardVectorVNSelection.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBackwardVectorVNSelection_h

--- a/mo/src/neighborhood/moDummyNeighbor.h
+++ b/mo/src/neighborhood/moDummyNeighbor.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyNeighbor_h

--- a/mo/src/neighborhood/moDummyNeighborhood.h
+++ b/mo/src/neighborhood/moDummyNeighborhood.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moDummyNeighborhood_h

--- a/mo/src/neighborhood/moEvaluatedNeighborhood.h
+++ b/mo/src/neighborhood/moEvaluatedNeighborhood.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moEvaluatedNeighborhood_h

--- a/mo/src/neighborhood/moForwardVectorVNSelection.h
+++ b/mo/src/neighborhood/moForwardVectorVNSelection.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moForwardVectorVNSelection_h

--- a/mo/src/neighborhood/moIndexNeighbor.h
+++ b/mo/src/neighborhood/moIndexNeighbor.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _IndexNeighbor_h

--- a/mo/src/neighborhood/moIndexNeighborhood.h
+++ b/mo/src/neighborhood/moIndexNeighborhood.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moIndexNeighborhood_h

--- a/mo/src/neighborhood/moNeighbor.h
+++ b/mo/src/neighborhood/moNeighbor.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moNeighbor_h

--- a/mo/src/neighborhood/moNeighborhood.h
+++ b/mo/src/neighborhood/moNeighborhood.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeighborhood_h

--- a/mo/src/neighborhood/moOrderNeighborhood.h
+++ b/mo/src/neighborhood/moOrderNeighborhood.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moOrderNeighborhood_h

--- a/mo/src/neighborhood/moRndNeighborhood.h
+++ b/mo/src/neighborhood/moRndNeighborhood.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRndNeighborhood_h

--- a/mo/src/neighborhood/moRndVectorVNSelection.h
+++ b/mo/src/neighborhood/moRndVectorVNSelection.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRndVectorVNSelection_h

--- a/mo/src/neighborhood/moRndWithReplNeighborhood.h
+++ b/mo/src/neighborhood/moRndWithReplNeighborhood.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRndWithReplNeighborhood_h

--- a/mo/src/neighborhood/moRndWithoutReplNeighborhood.h
+++ b/mo/src/neighborhood/moRndWithoutReplNeighborhood.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRndWithoutReplNeighborhood_h

--- a/mo/src/neighborhood/moVariableNeighborhoodSelection.h
+++ b/mo/src/neighborhood/moVariableNeighborhoodSelection.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moVariableNeighborhoodSelection_h

--- a/mo/src/neighborhood/moVectorVNSelection.h
+++ b/mo/src/neighborhood/moVectorVNSelection.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moVectorVNSelection_h

--- a/mo/src/perturb/moLocalSearchInit.h
+++ b/mo/src/perturb/moLocalSearchInit.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moLocalSearchInit_h

--- a/mo/src/perturb/moMonOpPerturb.h
+++ b/mo/src/perturb/moMonOpPerturb.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moMonOpPerturb_h

--- a/mo/src/perturb/moNeighborhoodPerturb.h
+++ b/mo/src/perturb/moNeighborhoodPerturb.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNeighborhoodPerturb_h

--- a/mo/src/perturb/moPerturbation.h
+++ b/mo/src/perturb/moPerturbation.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moPertubation_h

--- a/mo/src/perturb/moRestartPerturb.h
+++ b/mo/src/perturb/moRestartPerturb.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRestartPerturb_h

--- a/mo/src/perturb/moSolInit.h
+++ b/mo/src/perturb/moSolInit.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSolInit_h

--- a/mo/src/problems/bitString/moBitFlipNeighborhood.h
+++ b/mo/src/problems/bitString/moBitFlipNeighborhood.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
  
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moBitFlipNeighborhood_h

--- a/mo/src/problems/bitString/moBitNeighbor.h
+++ b/mo/src/problems/bitString/moBitNeighbor.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _bitNeighbor_h

--- a/mo/src/problems/bitString/moBitsNeighbor.h
+++ b/mo/src/problems/bitString/moBitsNeighbor.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBitsNeighbor_h

--- a/mo/src/problems/bitString/moBitsNeighborhood.h
+++ b/mo/src/problems/bitString/moBitsNeighborhood.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
  
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moBitsNeighborhood_h

--- a/mo/src/problems/bitString/moBitsWithReplNeighborhood.h
+++ b/mo/src/problems/bitString/moBitsWithReplNeighborhood.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBitsWithReplNeighborhood_h

--- a/mo/src/problems/bitString/moBitsWithoutReplNeighborhood.h
+++ b/mo/src/problems/bitString/moBitsWithoutReplNeighborhood.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moBitsWithoutReplNeighborhood_h

--- a/mo/src/problems/eval/moMaxSATincrEval.h
+++ b/mo/src/problems/eval/moMaxSATincrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moMaxSATincrEval_h

--- a/mo/src/problems/eval/moNKlandscapesBitsIncrEval.h
+++ b/mo/src/problems/eval/moNKlandscapesBitsIncrEval.h
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
  
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moNKlandscapesBitsIncrEval_H

--- a/mo/src/problems/eval/moNKlandscapesIncrEval.h
+++ b/mo/src/problems/eval/moNKlandscapesIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moNKlandscapesIncrEval_H

--- a/mo/src/problems/eval/moOneMaxBitsIncrEval.h
+++ b/mo/src/problems/eval/moOneMaxBitsIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moOneMaxBitsIncrEval_H

--- a/mo/src/problems/eval/moOneMaxIncrEval.h
+++ b/mo/src/problems/eval/moOneMaxIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moOneMaxIncrEval_H

--- a/mo/src/problems/eval/moQAPIncrEval.h
+++ b/mo/src/problems/eval/moQAPIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moQAPIncrEval_H

--- a/mo/src/problems/eval/moRoyalRoadIncrEval.h
+++ b/mo/src/problems/eval/moRoyalRoadIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moRoyalRoadIncrEval_H

--- a/mo/src/problems/eval/moUBQPBitsIncrEval.h
+++ b/mo/src/problems/eval/moUBQPBitsIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moUBQPBitsIncrEval_H

--- a/mo/src/problems/eval/moUBQPSimpleIncrEval.h
+++ b/mo/src/problems/eval/moUBQPSimpleIncrEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moUBQPSimpleIncrEval_H

--- a/mo/src/problems/eval/moUBQPdoubleIncrEvaluation.h
+++ b/mo/src/problems/eval/moUBQPdoubleIncrEvaluation.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moUBQPdoubleIncrEvaluation_H

--- a/mo/src/problems/permutation/moIndexedSwapNeighbor.h
+++ b/mo/src/problems/permutation/moIndexedSwapNeighbor.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moIndexedSwapNeighbor_h

--- a/mo/src/problems/permutation/moShiftNeighbor.h
+++ b/mo/src/problems/permutation/moShiftNeighbor.h
@@ -23,8 +23,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moShiftNeighbor_h

--- a/mo/src/problems/permutation/moSwapNeighbor.h
+++ b/mo/src/problems/permutation/moSwapNeighbor.h
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moSwapNeighbor_h

--- a/mo/src/problems/permutation/moSwapNeighborhood.h
+++ b/mo/src/problems/permutation/moSwapNeighborhood.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moSwapNeighborhood_h

--- a/mo/src/problems/permutation/moTwoOptExNeighbor.h
+++ b/mo/src/problems/permutation/moTwoOptExNeighbor.h
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
  
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moTwoOptExNeighbor_h

--- a/mo/src/problems/permutation/moTwoOptExNeighborhood.h
+++ b/mo/src/problems/permutation/moTwoOptExNeighborhood.h
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
  
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moTwoOptExNeighborhood_h

--- a/mo/src/sampling/moAdaptiveWalkSampling.h
+++ b/mo/src/sampling/moAdaptiveWalkSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moAdaptiveWalkSampling_h

--- a/mo/src/sampling/moAutocorrelationSampling.h
+++ b/mo/src/sampling/moAutocorrelationSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moAutocorrelationSampling_h

--- a/mo/src/sampling/moDensityOfStatesSampling.h
+++ b/mo/src/sampling/moDensityOfStatesSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moDensityOfStatesSampling_h

--- a/mo/src/sampling/moFDCsampling.h
+++ b/mo/src/sampling/moFDCsampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moFDCsampling_h

--- a/mo/src/sampling/moFitnessCloudSampling.h
+++ b/mo/src/sampling/moFitnessCloudSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moFitnessCloudSampling_h

--- a/mo/src/sampling/moHillClimberSampling.h
+++ b/mo/src/sampling/moHillClimberSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moHillClimberSampling_h

--- a/mo/src/sampling/moMHBestFitnessCloudSampling.h
+++ b/mo/src/sampling/moMHBestFitnessCloudSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMHBestFitnessCloudSampling_h

--- a/mo/src/sampling/moMHRndFitnessCloudSampling.h
+++ b/mo/src/sampling/moMHRndFitnessCloudSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moMHRndFitnessCloudSampling_h

--- a/mo/src/sampling/moNeutralDegreeSampling.h
+++ b/mo/src/sampling/moNeutralDegreeSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeutralDegreeSampling_h

--- a/mo/src/sampling/moNeutralWalkSampling.h
+++ b/mo/src/sampling/moNeutralWalkSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moNeutralWalkSampling_h

--- a/mo/src/sampling/moRndBestFitnessCloudSampling.h
+++ b/mo/src/sampling/moRndBestFitnessCloudSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moRndBestFitnessCloudSampling_h

--- a/mo/src/sampling/moRndRndFitnessCloudSampling.h
+++ b/mo/src/sampling/moRndRndFitnessCloudSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moRndRndFitnessCloudSampling_h

--- a/mo/src/sampling/moSampling.h
+++ b/mo/src/sampling/moSampling.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef moSampling_h

--- a/mo/src/sampling/moStatistics.h
+++ b/mo/src/sampling/moStatistics.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef moStatistics_h

--- a/mo/test/moTestClass.h
+++ b/mo/test/moTestClass.h
@@ -28,8 +28,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moTestClass_h

--- a/mo/test/t-moAdaptiveWalkSampling.cpp
+++ b/mo/test/t-moAdaptiveWalkSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moAlwaysAcceptCrit.cpp
+++ b/mo/test/t-moAlwaysAcceptCrit.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moAutocorrelationSampling.cpp
+++ b/mo/test/t-moAutocorrelationSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moBestImprAspiration.cpp
+++ b/mo/test/t-moBestImprAspiration.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 #include <memory/moBestImprAspiration.h>
 #include "moTestClass.h"

--- a/mo/test/t-moBetterAcceptCrit.cpp
+++ b/mo/test/t-moBetterAcceptCrit.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moBitNeighbor.cpp
+++ b/mo/test/t-moBitNeighbor.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <problems/bitString/moBitNeighbor.h>

--- a/mo/test/t-moCheckpoint.cpp
+++ b/mo/test/t-moCheckpoint.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moCheckpoint.h>

--- a/mo/test/t-moCombinedContinuator.cpp
+++ b/mo/test/t-moCombinedContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moCountMoveMemory.cpp
+++ b/mo/test/t-moCountMoveMemory.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moCounterMonitorSaver.cpp
+++ b/mo/test/t-moCounterMonitorSaver.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moCounterMonitorSaver.h>

--- a/mo/test/t-moCounterStat.cpp
+++ b/mo/test/t-moCounterStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDensityOfStatesSampling.cpp
+++ b/mo/test/t-moDensityOfStatesSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDistanceStat.cpp
+++ b/mo/test/t-moDistanceStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <problems/bitString/moBitNeighbor.h>

--- a/mo/test/t-moDummyEval.cpp
+++ b/mo/test/t-moDummyEval.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDummyExplorer.cpp
+++ b/mo/test/t-moDummyExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDummyLS.cpp
+++ b/mo/test/t-moDummyLS.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDummyMemory.cpp
+++ b/mo/test/t-moDummyMemory.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <memory/moDummyIntensification.h>

--- a/mo/test/t-moDummyNeighbor.cpp
+++ b/mo/test/t-moDummyNeighbor.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDummyNeighborhood.cpp
+++ b/mo/test/t-moDummyNeighborhood.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moDynSpanCoolingSchedule.cpp
+++ b/mo/test/t-moDynSpanCoolingSchedule.cpp
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #include <iostream>

--- a/mo/test/t-moEvalCounter.cpp
+++ b/mo/test/t-moEvalCounter.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moFDCsampling.cpp
+++ b/mo/test/t-moFDCsampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moFirstImprHC.cpp
+++ b/mo/test/t-moFirstImprHC.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moFirstImprHCexplorer.cpp
+++ b/mo/test/t-moFirstImprHCexplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <comparator/moNeighborComparator.h>

--- a/mo/test/t-moFitContinuator.cpp
+++ b/mo/test/t-moFitContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moFitnessCloudSampling.cpp
+++ b/mo/test/t-moFitnessCloudSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moFitnessStat.cpp
+++ b/mo/test/t-moFitnessStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moFitnessStat.h>

--- a/mo/test/t-moFullEvalByCopy.cpp
+++ b/mo/test/t-moFullEvalByCopy.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moTestClass.h"

--- a/mo/test/t-moFullEvalByModif.cpp
+++ b/mo/test/t-moFullEvalByModif.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moTestClass.h"

--- a/mo/test/t-moFullEvalContinuator.cpp
+++ b/mo/test/t-moFullEvalContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moHillClimberSampling.cpp
+++ b/mo/test/t-moHillClimberSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moILS.cpp
+++ b/mo/test/t-moILS.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moILSexplorer.cpp
+++ b/mo/test/t-moILSexplorer.cpp
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #include <iostream>

--- a/mo/test/t-moIndexedVectorTabuList.cpp
+++ b/mo/test/t-moIndexedVectorTabuList.cpp
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #include <memory/moIndexedVectorTabuList.h>

--- a/mo/test/t-moIterContinuator.cpp
+++ b/mo/test/t-moIterContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moLocalSearch.cpp
+++ b/mo/test/t-moLocalSearch.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moLocalSearchInit.cpp
+++ b/mo/test/t-moLocalSearchInit.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moMetropolisHasting.cpp
+++ b/mo/test/t-moMetropolisHasting.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moMetropolisHastingExplorer.cpp
+++ b/mo/test/t-moMetropolisHastingExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <explorer/moMetropolisHastingExplorer.h>

--- a/mo/test/t-moMinusOneCounterStat.cpp
+++ b/mo/test/t-moMinusOneCounterStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moMonOpDiversification.cpp
+++ b/mo/test/t-moMonOpDiversification.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moMonOpPerturb.cpp
+++ b/mo/test/t-moMonOpPerturb.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNKlandscapesIncrEval.cpp
+++ b/mo/test/t-moNKlandscapesIncrEval.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <ga/eoBit.h>                         

--- a/mo/test/t-moNeighbor.cpp
+++ b/mo/test/t-moNeighbor.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moTestClass.h"

--- a/mo/test/t-moNeighborBestStat.cpp
+++ b/mo/test/t-moNeighborBestStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeighborComparator.cpp
+++ b/mo/test/t-moNeighborComparator.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <problems/bitString/moBitNeighbor.h>

--- a/mo/test/t-moNeighborEvalContinuator.cpp
+++ b/mo/test/t-moNeighborEvalContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeighborFitnessStat.cpp
+++ b/mo/test/t-moNeighborFitnessStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeighborVectorTabuList.cpp
+++ b/mo/test/t-moNeighborVectorTabuList.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <memory/moNeighborVectorTabuList.h>

--- a/mo/test/t-moNeighborhoodPerturb.cpp
+++ b/mo/test/t-moNeighborhoodPerturb.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeighborhoodStat.cpp
+++ b/mo/test/t-moNeighborhoodStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moNeighborhoodStat.h>

--- a/mo/test/t-moNeutralDegreeSampling.cpp
+++ b/mo/test/t-moNeutralDegreeSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeutralHC.cpp
+++ b/mo/test/t-moNeutralHC.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moNeutralHCexplorer.cpp
+++ b/mo/test/t-moNeutralHCexplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <comparator/moNeighborComparator.h>

--- a/mo/test/t-moNeutralWalkSampling.cpp
+++ b/mo/test/t-moNeutralWalkSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moOrderNeighborhood.cpp
+++ b/mo/test/t-moOrderNeighborhood.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <neighborhood/moOrderNeighborhood.h>

--- a/mo/test/t-moRandomBestHC.cpp
+++ b/mo/test/t-moRandomBestHC.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRandomBestHCexplorer.cpp
+++ b/mo/test/t-moRandomBestHCexplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <comparator/moNeighborComparator.h>

--- a/mo/test/t-moRandomNeutralWalk.cpp
+++ b/mo/test/t-moRandomNeutralWalk.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRandomNeutralWalkExplorer.cpp
+++ b/mo/test/t-moRandomNeutralWalkExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <explorer/moRandomNeutralWalkExplorer.h>

--- a/mo/test/t-moRandomSearch.cpp
+++ b/mo/test/t-moRandomSearch.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRandomSearchExplorer.cpp
+++ b/mo/test/t-moRandomSearchExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRandomWalk.cpp
+++ b/mo/test/t-moRandomWalk.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRandomWalkExplorer.cpp
+++ b/mo/test/t-moRandomWalkExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <explorer/moRandomWalkExplorer.h>

--- a/mo/test/t-moRestartPerturb.cpp
+++ b/mo/test/t-moRestartPerturb.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moRndIndexedVectorTabuList.cpp
+++ b/mo/test/t-moRndIndexedVectorTabuList.cpp
@@ -23,8 +23,8 @@
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #include <memory/moRndIndexedVectorTabuList.h>

--- a/mo/test/t-moRndWithReplNeighborhood.cpp
+++ b/mo/test/t-moRndWithReplNeighborhood.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <neighborhood/moRndWithReplNeighborhood.h>

--- a/mo/test/t-moRndWithoutReplNeighborhood.cpp
+++ b/mo/test/t-moRndWithoutReplNeighborhood.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <neighborhood/moRndWithoutReplNeighborhood.h>

--- a/mo/test/t-moSA.cpp
+++ b/mo/test/t-moSA.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSAexplorer.cpp
+++ b/mo/test/t-moSAexplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSampling.cpp
+++ b/mo/test/t-moSampling.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSimpleCoolingSchedule.cpp
+++ b/mo/test/t-moSimpleCoolingSchedule.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSimpleHC.cpp
+++ b/mo/test/t-moSimpleHC.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSimpleHCexplorer.cpp
+++ b/mo/test/t-moSimpleHCexplorer.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moTestClass.h"

--- a/mo/test/t-moSolComparator.cpp
+++ b/mo/test/t-moSolComparator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSolInit.cpp
+++ b/mo/test/t-moSolInit.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moSolNeighborComparator.cpp
+++ b/mo/test/t-moSolNeighborComparator.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <problems/bitString/moBitNeighbor.h>

--- a/mo/test/t-moSolVectorTabuList.cpp
+++ b/mo/test/t-moSolVectorTabuList.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <memory/moSolVectorTabuList.h>

--- a/mo/test/t-moSolutionStat.cpp
+++ b/mo/test/t-moSolutionStat.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moSolutionStat.h>

--- a/mo/test/t-moStatistics.cpp
+++ b/mo/test/t-moStatistics.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moTS.cpp
+++ b/mo/test/t-moTS.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moTSexplorer.cpp
+++ b/mo/test/t-moTSexplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <memory/moSolVectorTabuList.h>

--- a/mo/test/t-moTimeContinuator.cpp
+++ b/mo/test/t-moTimeContinuator.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/test/t-moTrueContinuator.cpp
+++ b/mo/test/t-moTrueContinuator.cpp
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <continuator/moTrueContinuator.h>

--- a/mo/test/t-moVectorMonitor.cpp
+++ b/mo/test/t-moVectorMonitor.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/mo/tutorial/Lesson1/firstImprHC_maxSAT.cpp
+++ b/mo/tutorial/Lesson1/firstImprHC_maxSAT.cpp
@@ -218,5 +218,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_combinedContinuator.cpp
+++ b/mo/tutorial/Lesson1/lesson1_combinedContinuator.cpp
@@ -247,5 +247,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_evalContinuator.cpp
+++ b/mo/tutorial/Lesson1/lesson1_evalContinuator.cpp
@@ -214,5 +214,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_firstImprHC.cpp
+++ b/mo/tutorial/Lesson1/lesson1_firstImprHC.cpp
@@ -192,5 +192,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_fitContinuator.cpp
+++ b/mo/tutorial/Lesson1/lesson1_fitContinuator.cpp
@@ -209,5 +209,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_fullEvalContinuator.cpp
+++ b/mo/tutorial/Lesson1/lesson1_fullEvalContinuator.cpp
@@ -214,5 +214,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_iterContinuator.cpp
+++ b/mo/tutorial/Lesson1/lesson1_iterContinuator.cpp
@@ -211,5 +211,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_neutralHC.cpp
+++ b/mo/tutorial/Lesson1/lesson1_neutralHC.cpp
@@ -196,5 +196,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_randomBestHC.cpp
+++ b/mo/tutorial/Lesson1/lesson1_randomBestHC.cpp
@@ -192,5 +192,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson1/lesson1_simpleHC.cpp
+++ b/mo/tutorial/Lesson1/lesson1_simpleHC.cpp
@@ -193,5 +193,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson2/testNeighborhood.cpp
+++ b/mo/tutorial/Lesson2/testNeighborhood.cpp
@@ -237,5 +237,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson3/testSimulatedAnnealing.cpp
+++ b/mo/tutorial/Lesson3/testSimulatedAnnealing.cpp
@@ -228,5 +228,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson4/testSimpleTS.cpp
+++ b/mo/tutorial/Lesson4/testSimpleTS.cpp
@@ -262,5 +262,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson5/testILS.cpp
+++ b/mo/tutorial/Lesson5/testILS.cpp
@@ -226,5 +226,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/adaptiveWalks.cpp
+++ b/mo/tutorial/Lesson6/adaptiveWalks.cpp
@@ -207,5 +207,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/autocorrelation.cpp
+++ b/mo/tutorial/Lesson6/autocorrelation.cpp
@@ -222,5 +222,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/densityOfStates.cpp
+++ b/mo/tutorial/Lesson6/densityOfStates.cpp
@@ -190,5 +190,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/fdc.cpp
+++ b/mo/tutorial/Lesson6/fdc.cpp
@@ -188,5 +188,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/fitnessCloud.cpp
+++ b/mo/tutorial/Lesson6/fitnessCloud.cpp
@@ -213,5 +213,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/neutralDegree.cpp
+++ b/mo/tutorial/Lesson6/neutralDegree.cpp
@@ -211,5 +211,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/neutralWalk.cpp
+++ b/mo/tutorial/Lesson6/neutralWalk.cpp
@@ -247,5 +247,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/sampling.cpp
+++ b/mo/tutorial/Lesson6/sampling.cpp
@@ -252,5 +252,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/testMetropolisHasting.cpp
+++ b/mo/tutorial/Lesson6/testMetropolisHasting.cpp
@@ -197,5 +197,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/testRandomNeutralWalk.cpp
+++ b/mo/tutorial/Lesson6/testRandomNeutralWalk.cpp
@@ -274,5 +274,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson6/testRandomWalk.cpp
+++ b/mo/tutorial/Lesson6/testRandomWalk.cpp
@@ -239,5 +239,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson7/hybridAlgo.cpp
+++ b/mo/tutorial/Lesson7/hybridAlgo.cpp
@@ -218,5 +218,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/mo/tutorial/Lesson9/README.md
+++ b/mo/tutorial/Lesson9/README.md
@@ -1,0 +1,48 @@
+# Variable Neighborhood Search (VNS)
+
+VNS on the N-Queens problem, using multiple neighborhood structures to
+escape local optima.
+
+The N-Queens problem places N queens on an N x N chessboard so that no two
+queens attack each other. The representation is a permutation (one queen
+per column) and the fitness counts conflicts (minimized).
+
+## Running
+
+From the `build/mo/tutorial/Lesson9` directory:
+
+```shell
+./VNS -V=12
+```
+
+This runs VNS on a 12-queens instance with a 3-second time limit.
+
+## How it works
+
+VNS alternates between perturbation (shaking) and local search using
+different neighborhood structures. Here, two neighborhoods are used:
+
+```c++
+shiftNeighborhood shiftNH((vecSize-1) * (vecSize-1));
+swapNeighborhood swapNH(vecSize * (vecSize-1) / 2);
+```
+
+Each has its own hill-climber and mutation operator:
+
+```c++
+moSimpleHC<shiftNeighbor> ls1(shiftNH, fullEval, shiftEval);
+moSimpleHC<swapNeighbor> ls2(swapNH, fullEval, swapEval);
+
+moRndVectorVNSelection<Queen> selectNH(ls1, shiftMut, true);
+selectNH.add(ls2, swapMut);
+```
+
+`moRndVectorVNSelection` randomly picks which neighborhood/local search
+to apply at each iteration. Forward (`moForwardVectorVNSelection`) and
+backward (`moBackwardVectorVNSelection`) selection strategies are also
+available. The search runs until the `moTimeContinuator` time limit:
+
+```c++
+moTimeContinuator<shiftNeighbor> cont(3);  // 3 seconds
+moVNS<shiftNeighbor> vns(selectNH, acceptCrit, fullEval, cont);
+```

--- a/mo/tutorial/Lesson9/VNS.cpp
+++ b/mo/tutorial/Lesson9/VNS.cpp
@@ -284,5 +284,5 @@ int main(int argc, char **argv)
     catch (exception& e) {
         cout << "Exception: " << e.what() << '\n';
     }
-    return 1;
+    return 0;
 }

--- a/moeo/doc/index.h
+++ b/moeo/doc/index.h
@@ -16,7 +16,8 @@ using the whole version of ParadisEO.
 
 @section tutorials Tutorials
 
-Tutorials for ParadisEO-MOEO are available in the "Tutorials section" of the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+Tutorials for ParadisEO-MOEO are available in the moeo/tutorial/ directory. See also the
+<a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 
 
@@ -29,7 +30,7 @@ The installation procedure of the package is detailed in the README file in the 
 @section Design
 
 For an introduction to the design of ParadisEO-MOEO,
-you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+you can look at the <a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 
 @section LICENSE
@@ -58,14 +59,14 @@ you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
 
 */
 
 /** @page webpages Related webpages
 
-- ParadisEO <a href="http://paradiseo.gforge.inria.fr">homepage</a>
-- INRIA GForge <a href="http://gforge.inria.fr/projects/paradiseo/">project page</a>
+- ParadisEO <a href="https://nojhan.github.io/paradiseo/">homepage</a>
+- GitHub <a href="https://github.com/nojhan/paradiseo">project page</a>
 - <a href="../../README">README</a>
 */

--- a/moeo/doc/moeo.doxyfile.cmake
+++ b/moeo/doc/moeo.doxyfile.cmake
@@ -1295,7 +1295,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=http://eodev.sourceforge.net/eo/doc/html
+TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=https://nojhan.github.io/paradiseo/eo/doc/html
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.

--- a/moeo/src/algo/moeoASEEA.h
+++ b/moeo/src/algo/moeoASEEA.h
@@ -32,8 +32,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoAlgo.h
+++ b/moeo/src/algo/moeoAlgo.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoEA.h
+++ b/moeo/src/algo/moeoEA.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoEasyEA.h
+++ b/moeo/src/algo/moeoEasyEA.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoExtendedNSGAII.h
+++ b/moeo/src/algo/moeoExtendedNSGAII.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoExtendedSPEA2.h
+++ b/moeo/src/algo/moeoExtendedSPEA2.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoIBEA.h
+++ b/moeo/src/algo/moeoIBEA.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoMOGA.h
+++ b/moeo/src/algo/moeoMOGA.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoNSGA.h
+++ b/moeo/src/algo/moeoNSGA.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoNSGAII.h
+++ b/moeo/src/algo/moeoNSGAII.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoPLS1.h
+++ b/moeo/src/algo/moeoPLS1.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoPLS2.h
+++ b/moeo/src/algo/moeoPLS2.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoPopAlgo.h
+++ b/moeo/src/algo/moeoPopAlgo.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoPopLS.h
+++ b/moeo/src/algo/moeoPopLS.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoSEEA.h
+++ b/moeo/src/algo/moeoSEEA.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 

--- a/moeo/src/algo/moeoSPEA2.h
+++ b/moeo/src/algo/moeoSPEA2.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/algo/moeoUnifiedDominanceBasedLS.h
+++ b/moeo/src/algo/moeoUnifiedDominanceBasedLS.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeo2DMinHypervolumeArchive.h
+++ b/moeo/src/archive/moeo2DMinHypervolumeArchive.h
@@ -33,8 +33,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoArchive.h
+++ b/moeo/src/archive/moeoArchive.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoBoundedArchive.h
+++ b/moeo/src/archive/moeoBoundedArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoEpsilonHyperboxArchive.h
+++ b/moeo/src/archive/moeoEpsilonHyperboxArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoFitDivBoundedArchive.h
+++ b/moeo/src/archive/moeoFitDivBoundedArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoFixedSizeArchive.h
+++ b/moeo/src/archive/moeoFixedSizeArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoFuzzyArchive.h
+++ b/moeo/src/archive/moeoFuzzyArchive.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoImprOnlyBoundedArchive.h
+++ b/moeo/src/archive/moeoImprOnlyBoundedArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoSPEA2Archive.h
+++ b/moeo/src/archive/moeoSPEA2Archive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/archive/moeoUnboundedArchive.h
+++ b/moeo/src/archive/moeoUnboundedArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoAggregativeComparator.h
+++ b/moeo/src/comparator/moeoAggregativeComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoComparator.h
+++ b/moeo/src/comparator/moeoComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoDiversityThenFitnessComparator.h
+++ b/moeo/src/comparator/moeoDiversityThenFitnessComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoEpsilonObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoEpsilonObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoFitnessComparator.h
+++ b/moeo/src/comparator/moeoFitnessComparator.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoFitnessThenDiversityComparator.h
+++ b/moeo/src/comparator/moeoFitnessThenDiversityComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoFuzzyParetoComparator.h
+++ b/moeo/src/comparator/moeoFuzzyParetoComparator.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoGDominanceObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoGDominanceObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoObjectiveObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoObjectiveObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoOneObjectiveComparator.h
+++ b/moeo/src/comparator/moeoOneObjectiveComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoParetoDualObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoParetoDualObjectiveVectorComparator.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/comparator/moeoParetoObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoParetoObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoStrictObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoStrictObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/comparator/moeoWeakObjectiveVectorComparator.h
+++ b/moeo/src/comparator/moeoWeakObjectiveVectorComparator.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/continue/moeoDualHypContinue.h
+++ b/moeo/src/continue/moeoDualHypContinue.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/continue/moeoHypContinue.h
+++ b/moeo/src/continue/moeoHypContinue.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/MOEO.h
+++ b/moeo/src/core/MOEO.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoBitVector.h
+++ b/moeo/src/core/moeoBitVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoDualRealObjectiveVector.h
+++ b/moeo/src/core/moeoDualRealObjectiveVector.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/core/moeoEvalFunc.h
+++ b/moeo/src/core/moeoEvalFunc.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoFuzzyRealObjectiveVector.h
+++ b/moeo/src/core/moeoFuzzyRealObjectiveVector.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoIntVector.h
+++ b/moeo/src/core/moeoIntVector.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoObjectiveVector.h
+++ b/moeo/src/core/moeoObjectiveVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoObjectiveVectorTraits.cpp
+++ b/moeo/src/core/moeoObjectiveVectorTraits.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoObjectiveVectorTraits.h
+++ b/moeo/src/core/moeoObjectiveVectorTraits.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoRealObjectiveVector.h
+++ b/moeo/src/core/moeoRealObjectiveVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoRealVector.h
+++ b/moeo/src/core/moeoRealVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/core/moeoScalarObjectiveVector.h
+++ b/moeo/src/core/moeoScalarObjectiveVector.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/core/moeoVector.h
+++ b/moeo/src/core/moeoVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoBertDistance.h
+++ b/moeo/src/distance/moeoBertDistance.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoDistance.h
+++ b/moeo/src/distance/moeoDistance.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoDistanceMatrix.h
+++ b/moeo/src/distance/moeoDistanceMatrix.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoEuclideanDistance.h
+++ b/moeo/src/distance/moeoEuclideanDistance.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoExpectedFuzzyDistance.h
+++ b/moeo/src/distance/moeoExpectedFuzzyDistance.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoManhattanDistance.h
+++ b/moeo/src/distance/moeoManhattanDistance.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoNormalizedDistance.h
+++ b/moeo/src/distance/moeoNormalizedDistance.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/distance/moeoObjSpaceDistance.h
+++ b/moeo/src/distance/moeoObjSpaceDistance.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoCrowdingDiversityAssignment.h
+++ b/moeo/src/diversity/moeoCrowdingDiversityAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoDiversityAssignment.h
+++ b/moeo/src/diversity/moeoDiversityAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoDummyDiversityAssignment.h
+++ b/moeo/src/diversity/moeoDummyDiversityAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoFrontByFrontCrowdingDiversityAssignment.h
+++ b/moeo/src/diversity/moeoFrontByFrontCrowdingDiversityAssignment.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoFrontByFrontSharingDiversityAssignment.h
+++ b/moeo/src/diversity/moeoFrontByFrontSharingDiversityAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoFuzzyCrowdingDiversity.h
+++ b/moeo/src/diversity/moeoFuzzyCrowdingDiversity.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoFuzzyNearestNeighborDiversity.h
+++ b/moeo/src/diversity/moeoFuzzyNearestNeighborDiversity.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoNearestNeighborDiversityAssignment.h
+++ b/moeo/src/diversity/moeoNearestNeighborDiversityAssignment.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/diversity/moeoSharingDiversityAssignment.h
+++ b/moeo/src/diversity/moeoSharingDiversityAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/do/make_checkpoint_moeo.h
+++ b/moeo/src/do/make_checkpoint_moeo.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/do/make_continue_moeo.h
+++ b/moeo/src/do/make_continue_moeo.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/do/make_ea_moeo.h
+++ b/moeo/src/do/make_ea_moeo.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoExhaustiveNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoExhaustiveNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoFirstImprovingNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoFirstImprovingNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoNoDesimprovingNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoNoDesimprovingNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoPopNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoPopNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoSimpleSubNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoSimpleSubNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/explorer/moeoSubNeighborhoodExplorer.h
+++ b/moeo/src/explorer/moeoSubNeighborhoodExplorer.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoAggregationFitnessAssignment.h
+++ b/moeo/src/fitness/moeoAggregationFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoBinaryIndicatorBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoBinaryIndicatorBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoConstraintFitnessAssignment.h
+++ b/moeo/src/fitness/moeoConstraintFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoCriterionBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoCriterionBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDominanceBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDominanceBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDominanceCountFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDominanceCountFitnessAssignment.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDominanceCountRankingFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDominanceCountRankingFitnessAssignment.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDominanceDepthFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDominanceDepthFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDominanceRankFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDominanceRankFitnessAssignment.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoDummyFitnessAssignment.h
+++ b/moeo/src/fitness/moeoDummyFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoExpBinaryIndicatorBasedDualFitnessAssignment.h
+++ b/moeo/src/fitness/moeoExpBinaryIndicatorBasedDualFitnessAssignment.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/fitness/moeoExpBinaryIndicatorBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoExpBinaryIndicatorBasedFitnessAssignment.h
@@ -34,8 +34,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoFitnessAssignment.h
+++ b/moeo/src/fitness/moeoFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoIndicatorBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoIndicatorBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoReferencePointIndicatorBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoReferencePointIndicatorBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoScalarFitnessAssignment.h
+++ b/moeo/src/fitness/moeoScalarFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoSingleObjectivization.h
+++ b/moeo/src/fitness/moeoSingleObjectivization.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/fitness/moeoUnaryIndicatorBasedFitnessAssignment.h
+++ b/moeo/src/fitness/moeoUnaryIndicatorBasedFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/hybridization/moeoDMLSGenUpdater.h
+++ b/moeo/src/hybridization/moeoDMLSGenUpdater.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/hybridization/moeoDMLSMonOp.h
+++ b/moeo/src/hybridization/moeoDMLSMonOp.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoAdditiveEpsilonBinaryMetric.h
+++ b/moeo/src/metric/moeoAdditiveEpsilonBinaryMetric.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoContributionMetric.h
+++ b/moeo/src/metric/moeoContributionMetric.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoDistanceMetric.h
+++ b/moeo/src/metric/moeoDistanceMetric.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoDualHyperVolumeDifferenceMetric.h
+++ b/moeo/src/metric/moeoDualHyperVolumeDifferenceMetric.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/metric/moeoEntropyMetric.h
+++ b/moeo/src/metric/moeoEntropyMetric.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoHyperVolumeDifferenceMetric.h
+++ b/moeo/src/metric/moeoHyperVolumeDifferenceMetric.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoHyperVolumeMetric.h
+++ b/moeo/src/metric/moeoHyperVolumeMetric.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoHypervolumeBinaryMetric.h
+++ b/moeo/src/metric/moeoHypervolumeBinaryMetric.h
@@ -30,8 +30,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoMetric.h
+++ b/moeo/src/metric/moeoMetric.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoNormalizedSolutionVsSolutionBinaryMetric.h
+++ b/moeo/src/metric/moeoNormalizedSolutionVsSolutionBinaryMetric.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoVecVsVecAdditiveEpsilonBinaryMetric.h
+++ b/moeo/src/metric/moeoVecVsVecAdditiveEpsilonBinaryMetric.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoVecVsVecEpsilonBinaryMetric.h
+++ b/moeo/src/metric/moeoVecVsVecEpsilonBinaryMetric.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/metric/moeoVecVsVecMultiplicativeEpsilonBinaryMetric.h
+++ b/moeo/src/metric/moeoVecVsVecMultiplicativeEpsilonBinaryMetric.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/moeo
+++ b/moeo/src/moeo
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/replacement/moeoElitistReplacement.h
+++ b/moeo/src/replacement/moeoElitistReplacement.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/replacement/moeoEnvironmentalReplacement.h
+++ b/moeo/src/replacement/moeoEnvironmentalReplacement.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/replacement/moeoGenerationalReplacement.h
+++ b/moeo/src/replacement/moeoGenerationalReplacement.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/replacement/moeoReplacement.h
+++ b/moeo/src/replacement/moeoReplacement.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/algo/moeoHC.h
+++ b/moeo/src/scalarStuffs/algo/moeoHC.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef __moeoHC_h

--- a/moeo/src/scalarStuffs/algo/moeoILS.h
+++ b/moeo/src/scalarStuffs/algo/moeoILS.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moeoILS_h

--- a/moeo/src/scalarStuffs/algo/moeoSA.h
+++ b/moeo/src/scalarStuffs/algo/moeoSA.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef __moeoSA_h

--- a/moeo/src/scalarStuffs/algo/moeoSolAlgo.h
+++ b/moeo/src/scalarStuffs/algo/moeoSolAlgo.h
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/algo/moeoTS.h
+++ b/moeo/src/scalarStuffs/algo/moeoTS.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef __moeoTS_h

--- a/moeo/src/scalarStuffs/algo/moeoVFAS.h
+++ b/moeo/src/scalarStuffs/algo/moeoVFAS.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moeoVFAS_h

--- a/moeo/src/scalarStuffs/algo/moeoVNS.h
+++ b/moeo/src/scalarStuffs/algo/moeoVNS.h
@@ -30,8 +30,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef _moeoVNS_h

--- a/moeo/src/scalarStuffs/archive/moeoQuadTree.h
+++ b/moeo/src/scalarStuffs/archive/moeoQuadTree.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/archive/moeoQuadTreeArchive.h
+++ b/moeo/src/scalarStuffs/archive/moeoQuadTreeArchive.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/distance/moeoAchievementScalarizingFunctionDistance.h
+++ b/moeo/src/scalarStuffs/distance/moeoAchievementScalarizingFunctionDistance.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/distance/moeoAugmentedAchievementScalarizingFunctionDistance.h
+++ b/moeo/src/scalarStuffs/distance/moeoAugmentedAchievementScalarizingFunctionDistance.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/distance/moeoAugmentedWeightedChebychevDistance.h
+++ b/moeo/src/scalarStuffs/distance/moeoAugmentedWeightedChebychevDistance.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/distance/moeoWeightedChebychevDistance.h
+++ b/moeo/src/scalarStuffs/distance/moeoWeightedChebychevDistance.h
@@ -31,8 +31,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *       
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr 
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues 
  *               
  */ 
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/explorer/moeoHCMoveLoopExpl.h
+++ b/moeo/src/scalarStuffs/explorer/moeoHCMoveLoopExpl.h
@@ -29,8 +29,8 @@
    The fact that you are presently reading this means that you have had
    knowledge of the CeCILL license and that you accept its terms.
 
-   ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+   ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
  */
 
 #ifndef __moeoHCLoopExpl_h

--- a/moeo/src/scalarStuffs/explorer/moeoTSMoveLoopExpl.h
+++ b/moeo/src/scalarStuffs/explorer/moeoTSMoveLoopExpl.h
@@ -29,8 +29,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
  
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moeoTSMoveLoopExpl_h

--- a/moeo/src/scalarStuffs/fitness/moeoAchievementFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoAchievementFitnessAssignment.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoAchievementScalarizingFunctionMetricFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoAchievementScalarizingFunctionMetricFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoAugmentedAchievementScalarizingFunctionMetricFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoAugmentedAchievementScalarizingFunctionMetricFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoAugmentedWeightedChebychevMetricFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoAugmentedWeightedChebychevMetricFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoIncrEvalSingleObjectivizer.h
+++ b/moeo/src/scalarStuffs/fitness/moeoIncrEvalSingleObjectivizer.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoMetricFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoMetricFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/fitness/moeoWeightedChebychevMetricFitnessAssignment.h
+++ b/moeo/src/scalarStuffs/fitness/moeoWeightedChebychevMetricFitnessAssignment.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoAnytimeWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoAnytimeWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoAugmentedQexploreWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoAugmentedQexploreWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoDichoWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoDichoWeightStrategy.h
@@ -29,8 +29,8 @@
  * The fact that you are presently reading this means that you have had
  * knowledge of the CeCILL license and that you accept its terms.
  *
- * ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- * Contact: paradiseo-help@lists.gforge.inria.fr
+ * ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ * Contact: https://github.com/nojhan/paradiseo/issues
  *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoDummyRefPointStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoDummyRefPointStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoDummyWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoDummyWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoFixedTimeBothDirectionWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoFixedTimeBothDirectionWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoFixedTimeOneDirectionWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoFixedTimeOneDirectionWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoQexploreWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoQexploreWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
  */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoRandWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoRandWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoVariableRefPointStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoVariableRefPointStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/scalarStuffs/weighting/moeoVariableWeightStrategy.h
+++ b/moeo/src/scalarStuffs/weighting/moeoVariableWeightStrategy.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoDetArchiveSelect.h
+++ b/moeo/src/selection/moeoDetArchiveSelect.h
@@ -32,8 +32,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoDetTournamentSelect.h
+++ b/moeo/src/selection/moeoDetTournamentSelect.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoExhaustiveUnvisitedSelect.h
+++ b/moeo/src/selection/moeoExhaustiveUnvisitedSelect.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoNumberUnvisitedSelect.h
+++ b/moeo/src/selection/moeoNumberUnvisitedSelect.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoRandomSelect.h
+++ b/moeo/src/selection/moeoRandomSelect.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoRouletteSelect.h
+++ b/moeo/src/selection/moeoRouletteSelect.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoSelectFromPopAndArch.h
+++ b/moeo/src/selection/moeoSelectFromPopAndArch.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoSelectOne.h
+++ b/moeo/src/selection/moeoSelectOne.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoSelectors.h
+++ b/moeo/src/selection/moeoSelectors.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoStochTournamentSelect.h
+++ b/moeo/src/selection/moeoStochTournamentSelect.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/selection/moeoUnvisitedSelect.h
+++ b/moeo/src/selection/moeoUnvisitedSelect.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoArchiveObjectiveVectorSavingUpdater.h
+++ b/moeo/src/utils/moeoArchiveObjectiveVectorSavingUpdater.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoArchiveUpdater.h
+++ b/moeo/src/utils/moeoArchiveUpdater.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoAverageObjVecStat.h
+++ b/moeo/src/utils/moeoAverageObjVecStat.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoBestObjVecStat.h
+++ b/moeo/src/utils/moeoBestObjVecStat.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoBinaryMetricSavingUpdater.h
+++ b/moeo/src/utils/moeoBinaryMetricSavingUpdater.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoBinaryMetricStat.h
+++ b/moeo/src/utils/moeoBinaryMetricStat.h
@@ -16,7 +16,7 @@
     License along with this library; if not, write to the Free Software
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
-Contact: http://eodev.sourceforge.net
+Contact: https://nojhan.github.io/paradiseo
 
 Authors:
     Johann Dréo <johann.dreo@thalesgroup.com>

--- a/moeo/src/utils/moeoConvertPopToObjectiveVectors.h
+++ b/moeo/src/utils/moeoConvertPopToObjectiveVectors.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoDominanceMatrix.h
+++ b/moeo/src/utils/moeoDominanceMatrix.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoFuzzyObjectiveVectorNormalizer.h
+++ b/moeo/src/utils/moeoFuzzyObjectiveVectorNormalizer.h
@@ -5,8 +5,8 @@
 Author:
        Oumayma BAHRI <oumaymabahri.com>
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr	   
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues	   
 
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoObjVecStat.h
+++ b/moeo/src/utils/moeoObjVecStat.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/src/utils/moeoObjectiveVectorNormalizer.h
+++ b/moeo/src/utils/moeoObjectiveVectorNormalizer.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/moeoTestClass.h
+++ b/moeo/test/moeoTestClass.h
@@ -28,8 +28,8 @@
   The fact that you are presently reading this means that you have had
   knowledge of the CeCILL license and that you accept its terms.
 
-  ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-  Contact: paradiseo-help@lists.gforge.inria.fr
+  ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+  Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moeoTestClass_h

--- a/moeo/test/t-moeo.cpp
+++ b/moeo/test/t-moeo.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeo2DMinHypervolumeArchive.cpp
+++ b/moeo/test/t-moeo2DMinHypervolumeArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoASEEA.cpp
+++ b/moeo/test/t-moeoASEEA.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoASFAMetric.cpp
+++ b/moeo/test/t-moeoASFAMetric.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoASFAOrMetric.cpp
+++ b/moeo/test/t-moeoASFAOrMetric.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoAchievementFitnessAssignment.cpp
+++ b/moeo/test/t-moeoAchievementFitnessAssignment.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoAggregationFitnessAssignment.cpp
+++ b/moeo/test/t-moeoAggregationFitnessAssignment.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoAggregativeComparator.cpp
+++ b/moeo/test/t-moeoAggregativeComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoAggregativeFitnessAssignment.cpp
+++ b/moeo/test/t-moeoAggregativeFitnessAssignment.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoBitVector.cpp
+++ b/moeo/test/t-moeoBitVector.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoBoundedArchive.cpp
+++ b/moeo/test/t-moeoBoundedArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoChebyshevMetric.cpp
+++ b/moeo/test/t-moeoChebyshevMetric.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoChebyshevOrientedMetric.cpp
+++ b/moeo/test/t-moeoChebyshevOrientedMetric.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoConstraintFitnessAssignment.cpp
+++ b/moeo/test/t-moeoConstraintFitnessAssignment.cpp
@@ -31,8 +31,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoCrowdingDiversityAssignment.cpp
+++ b/moeo/test/t-moeoCrowdingDiversityAssignment.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDMLSGenUpdater.cpp
+++ b/moeo/test/t-moeoDMLSGenUpdater.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moeoTestClass.h"

--- a/moeo/test/t-moeoDMLSMonOp.cpp
+++ b/moeo/test/t-moeoDMLSMonOp.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoDetArchiveSelect.cpp
+++ b/moeo/test/t-moeoDetArchiveSelect.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDiversityThenFitnessComparator.cpp
+++ b/moeo/test/t-moeoDiversityThenFitnessComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDominanceCountFitnessAssignment.cpp
+++ b/moeo/test/t-moeoDominanceCountFitnessAssignment.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDominanceCountRankingFitnessAssignment.cpp
+++ b/moeo/test/t-moeoDominanceCountRankingFitnessAssignment.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDominanceDepthFitnessAssignment.cpp
+++ b/moeo/test/t-moeoDominanceDepthFitnessAssignment.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDominanceMatrix.cpp
+++ b/moeo/test/t-moeoDominanceMatrix.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoDominanceRankFitnessAssignment.cpp
+++ b/moeo/test/t-moeoDominanceRankFitnessAssignment.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoEasyEA.cpp
+++ b/moeo/test/t-moeoEasyEA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoEpsilonHyperboxArchive.cpp
+++ b/moeo/test/t-moeoEpsilonHyperboxArchive.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoEpsilonObjectiveVectorComparator.cpp
+++ b/moeo/test/t-moeoEpsilonObjectiveVectorComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoExhaustiveNeighborhoodExplorer.cpp
+++ b/moeo/test/t-moeoExhaustiveNeighborhoodExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moeoTestClass.h"

--- a/moeo/test/t-moeoExhaustiveUnvisitedSelect.cpp
+++ b/moeo/test/t-moeoExhaustiveUnvisitedSelect.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoExpBinaryIndicatorBasedFitnessAssignment.cpp
+++ b/moeo/test/t-moeoExpBinaryIndicatorBasedFitnessAssignment.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoFirstImprovingNeighborhoodExplorer.cpp
+++ b/moeo/test/t-moeoFirstImprovingNeighborhoodExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include "moeoTestClass.h"

--- a/moeo/test/t-moeoFitDivBoundedArchive.cpp
+++ b/moeo/test/t-moeoFitDivBoundedArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoFitnessThenDiversityComparator.cpp
+++ b/moeo/test/t-moeoFitnessThenDiversityComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoHyperVolumeDifferenceMetric.cpp
+++ b/moeo/test/t-moeoHyperVolumeDifferenceMetric.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoHyperVolumeMetric.cpp
+++ b/moeo/test/t-moeoHyperVolumeMetric.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoHypervolumeBinaryMetric.cpp
+++ b/moeo/test/t-moeoHypervolumeBinaryMetric.cpp
@@ -28,8 +28,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoIBEA.cpp
+++ b/moeo/test/t-moeoIBEA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoImprOnlyBoundedArchive.cpp
+++ b/moeo/test/t-moeoImprOnlyBoundedArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoIntVector.cpp
+++ b/moeo/test/t-moeoIntVector.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoMOGA.cpp
+++ b/moeo/test/t-moeoMOGA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoMax3Obj.cpp
+++ b/moeo/test/t-moeoMax3Obj.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoNSGA.cpp
+++ b/moeo/test/t-moeoNSGA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoNSGAII.cpp
+++ b/moeo/test/t-moeoNSGAII.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoNearestNeighborDiversityAssignment.cpp
+++ b/moeo/test/t-moeoNearestNeighborDiversityAssignment.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoNoDesimprovingNeighborhoodExplorer.cpp
+++ b/moeo/test/t-moeoNoDesimprovingNeighborhoodExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoNumberUnvisitedSelect.cpp
+++ b/moeo/test/t-moeoNumberUnvisitedSelect.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoPLS1.cpp
+++ b/moeo/test/t-moeoPLS1.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoPLS2.cpp
+++ b/moeo/test/t-moeoPLS2.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoParetoObjectiveVectorComparator.cpp
+++ b/moeo/test/t-moeoParetoObjectiveVectorComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoQuadTreeArchive.cpp
+++ b/moeo/test/t-moeoQuadTreeArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoRealVector.cpp
+++ b/moeo/test/t-moeoRealVector.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoSEEA.cpp
+++ b/moeo/test/t-moeoSEEA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoSPEA2.cpp
+++ b/moeo/test/t-moeoSPEA2.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoSPEA2Archive.cpp
+++ b/moeo/test/t-moeoSPEA2Archive.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoSharingDiversityAssignment.cpp
+++ b/moeo/test/t-moeoSharingDiversityAssignment.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoSimpleSubNeighborhoodExplorer.cpp
+++ b/moeo/test/t-moeoSimpleSubNeighborhoodExplorer.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <iostream>

--- a/moeo/test/t-moeoStrictObjectiveVectorComparator.cpp
+++ b/moeo/test/t-moeoStrictObjectiveVectorComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoUnboundedArchive.cpp
+++ b/moeo/test/t-moeoUnboundedArchive.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoVecVsVecAdditiveEpsilonBinaryMetric.cpp
+++ b/moeo/test/t-moeoVecVsVecAdditiveEpsilonBinaryMetric.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoVecVsVecMultiplicativeEpsilonBinaryMetric.cpp
+++ b/moeo/test/t-moeoVecVsVecMultiplicativeEpsilonBinaryMetric.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/test/t-moeoWeakObjectiveVectorComparator.cpp
+++ b/moeo/test/t-moeoWeakObjectiveVectorComparator.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/Lesson1/README.md
+++ b/moeo/tutorial/Lesson1/README.md
@@ -1,0 +1,84 @@
+# How to run your first multi-objective EA?
+
+In this lesson you will solve the Schaffer SCH1 bi-objective problem with
+NSGA-II using the ParadisEO-MOEO framework.
+
+The SCH1 problem minimizes two objectives over a single real-valued
+variable x in [0, 2]:
+
+- f1(x) = x^2
+- f2(x) = (x - 2)^2
+
+## 1. Running
+
+From the `build/moeo/tutorial/Lesson1` directory:
+
+```shell
+./Sch1 --help
+./Sch1 --popSize=100 --maxGen=100
+```
+
+Parameters can also be read from a file:
+
+```shell
+./Sch1 @Sch1.param
+```
+
+## 2. Browsing the code
+
+Open `Sch1.cpp` and follow along.
+
+First, define the objective vector traits. This tells MOEO how many
+objectives the problem has and whether each is minimizing or maximizing:
+
+```c++
+class Sch1ObjectiveVectorTraits : public moeoObjectiveVectorTraits
+{
+public:
+    static bool minimizing (int) { return true; }
+    static bool maximizing (int) { return false; }
+    static unsigned int nObjectives () { return 2; }
+};
+```
+
+The solution class `Sch1` inherits from `moeoRealVector` — a real-valued
+decision vector that also carries an objective vector:
+
+```c++
+class Sch1 : public moeoRealVector < Sch1ObjectiveVector >
+{
+public:
+    Sch1() : moeoRealVector < Sch1ObjectiveVector > (1) {}
+};
+```
+
+The evaluator computes both objectives and stores them via
+`objectiveVector()`:
+
+```c++
+void operator () (Sch1 & _sch1)
+{
+    if (_sch1.invalidObjectiveVector()) {
+        Sch1ObjectiveVector objVec;
+        double x = _sch1[0];
+        objVec[0] = x * x;
+        objVec[1] = (x - 2.0) * (x - 2.0);
+        _sch1.objectiveVector(objVec);
+    }
+}
+```
+
+The algorithm itself is a single line — `moeoNSGAII` takes the generation
+limit, evaluator, crossover, and mutation as constructor arguments:
+
+```c++
+moeoNSGAII < Sch1 > nsgaII (MAX_GEN, eval, xover, P_CROSS, mutation, P_MUT);
+```
+
+After the run, extract the Pareto front with `moeoUnboundedArchive`:
+
+```c++
+moeoUnboundedArchive < Sch1 > arch;
+arch(pop);
+arch.sortedPrintOn(cout);
+```

--- a/moeo/tutorial/Lesson1/Sch1.cpp
+++ b/moeo/tutorial/Lesson1/Sch1.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/Lesson2/FlowShopEA.cpp
+++ b/moeo/tutorial/Lesson2/FlowShopEA.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/Lesson2/README.md
+++ b/moeo/tutorial/Lesson2/README.md
@@ -1,0 +1,31 @@
+# Multi-objective EA on the flow-shop scheduling problem
+
+This lesson solves a more realistic combinatorial problem: the bi-objective
+permutation flow-shop, which minimizes both makespan and total flow time.
+
+## Running
+
+From the `build/moeo/tutorial/Lesson2` directory:
+
+```shell
+./FlowShopEA @FlowShopEA.param
+```
+
+The parameter file specifies the problem instance, population size, operator
+rates, and fitness assignment strategy.
+
+## How it works
+
+The code uses ParadisEO's `do_make_*` factory functions to build all
+components from command-line parameters:
+
+```c++
+eoEvalFuncCounter<FlowShop>& eval = do_make_eval(parser, state);
+eoInit<FlowShop>& init = do_make_genotype(parser, state);
+eoGenOp<FlowShop>& op = do_make_op(parser, state);
+```
+
+The flow-shop representation is defined in `FlowShop.h` — a
+permutation-based `moeoVector` with a bi-objective vector. Different
+Pareto-based fitness assignment strategies (NSGA-II, SPEA2, IBEA, etc.)
+can be selected via parameters.

--- a/moeo/tutorial/Lesson3/FlowShopEA2.cpp
+++ b/moeo/tutorial/Lesson3/FlowShopEA2.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/Lesson3/README.md
+++ b/moeo/tutorial/Lesson3/README.md
@@ -1,0 +1,32 @@
+# User-friendly multi-objective EA
+
+Same flow-shop problem as Lesson 2, but with a complete algorithmic pipeline
+built from reusable `do_make_*` helpers: stopping criteria, checkpointing,
+statistics, and the full evolution engine.
+
+## Running
+
+From the `build/moeo/tutorial/Lesson3` directory:
+
+```shell
+./FlowShopEA2 @FlowShopEA2.param
+```
+
+## How it works
+
+The main program is essentially a sequence of factory calls:
+
+```c++
+eoEvalFuncCounter<FlowShop>& eval = do_make_eval(parser, state);
+eoInit<FlowShop>& init = do_make_genotype(parser, state);
+eoPop<FlowShop>& pop = do_make_pop(parser, state, init);
+eoContinue<FlowShop>& term = do_make_continue_moeo(parser, state, eval);
+eoCheckPoint<FlowShop>& checkpoint = do_make_checkpoint_moeo(parser, state, ...);
+eoAlgo<FlowShop>& algo = do_make_ea_moeo(parser, state, ...);
+do_make_run(parser, state, algo, pop);
+```
+
+`do_make_continue_moeo` builds continuators (generation limit, fitness
+target, etc.) from parameters. `do_make_checkpoint_moeo` adds statistics,
+population snapshots, and archive tracking. `do_make_ea_moeo` constructs
+the selection and replacement strategy.

--- a/moeo/tutorial/Lesson4/FlowShopDMLS.cpp
+++ b/moeo/tutorial/Lesson4/FlowShopDMLS.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/Lesson4/README.md
+++ b/moeo/tutorial/Lesson4/README.md
@@ -1,0 +1,35 @@
+# Dominance-based multi-objective local search (DMLS)
+
+Same flow-shop problem as Lessons 2-3, but solved with local search instead
+of an evolutionary algorithm. This combines ParadisEO-MO local search
+components with the MOEO multi-objective framework.
+
+## Running
+
+From the `build/moeo/tutorial/Lesson4` directory:
+
+```shell
+./FlowShopDMLS @FlowShopDMLS.param
+```
+
+## How it works
+
+The program uses `moShiftNeighbor` and `moOrderNeighborhood` from
+ParadisEO-MO, with `moeoFullEvalByCopy` to adapt the full solution
+evaluator for neighbor evaluation:
+
+```c++
+typedef moShiftNeighbor<FlowShop, FlowShopObjectiveVector> Neighbor;
+
+moOrderNeighborhood<Neighbor> neighborhood((nhSize-1) * (nhSize-1));
+moeoFullEvalByCopy<Neighbor> moEval(eval);
+```
+
+At each iteration, DMLS explores all non-dominated solutions in the
+archive via local search moves and updates the archive with any improving
+neighbors:
+
+```c++
+moeoFirstImprovingNeighborhoodExplorer<Neighbor> explor(neighborhood, moEval);
+moeoUnifiedDominanceBasedLS<Neighbor> algo(checkpoint, eval, arch, explor, select);
+```

--- a/moeo/tutorial/examples/flowshop/FlowShop.cpp
+++ b/moeo/tutorial/examples/flowshop/FlowShop.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShop.h
+++ b/moeo/tutorial/examples/flowshop/FlowShop.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopBenchmarkParser.cpp
+++ b/moeo/tutorial/examples/flowshop/FlowShopBenchmarkParser.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopBenchmarkParser.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopBenchmarkParser.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopEval.cpp
+++ b/moeo/tutorial/examples/flowshop/FlowShopEval.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopEval.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopEval.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopInit.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopInit.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopObjectiveVector.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopObjectiveVector.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopObjectiveVectorTraits.cpp
+++ b/moeo/tutorial/examples/flowshop/FlowShopObjectiveVectorTraits.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopObjectiveVectorTraits.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopObjectiveVectorTraits.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopOpCrossoverQuad.cpp
+++ b/moeo/tutorial/examples/flowshop/FlowShopOpCrossoverQuad.cpp
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopOpCrossoverQuad.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopOpCrossoverQuad.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopOpMutationExchange.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopOpMutationExchange.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/FlowShopOpMutationShift.h
+++ b/moeo/tutorial/examples/flowshop/FlowShopOpMutationShift.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/make_eval_FlowShop.h
+++ b/moeo/tutorial/examples/flowshop/make_eval_FlowShop.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/make_genotype_FlowShop.h
+++ b/moeo/tutorial/examples/flowshop/make_genotype_FlowShop.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/moeo/tutorial/examples/flowshop/make_op_FlowShop.h
+++ b/moeo/tutorial/examples/flowshop/make_op_FlowShop.h
@@ -29,8 +29,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/README.txt
+++ b/problems/DTLZ/README.txt
@@ -8,7 +8,7 @@ On Windows write your path with double antislash (ex: C:\\Users\\...)
 
 # Step 2 - Build process
 ------------------------
-ParadisEO is assumed to be compiled. To download ParadisEO, please visit http://paradiseo.gforge.inria.fr/.
+ParadisEO is assumed to be compiled. To download ParadisEO, please visit https://nojhan.github.io/paradiseo/.
 Go to the DLTZ/build/ directory and lunch cmake:
 (Unix)       > cmake ..
 (Windows)    > cmake .. -G"Visual Studio 9 2008"
@@ -21,23 +21,23 @@ Note for windows users: if you don't use VisualStudio 9, enter the name of your 
 In the DTLZ/build/ directory:
 (Unix)       > make
 (Windows)    Open the VisualStudio solution and compile it (Windows).
-You can refer to this tutorial if you don't know how to compile a solution: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+You can refer to this tutorial if you don't know how to compile a solution: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 
 # Step 4 - Execution
 ---------------------
 A toy example is given to test the components. You can run these tests as following.
-To define problem-related components for your own problem, please refer to the tutorials available on the website : http://paradiseo.gforge.inria.fr/.
+To define problem-related components for your own problem, please refer to the tutorials available on the website : https://nojhan.github.io/paradiseo/.
 In the DTLZ/build/ directory:
 (Unix)       > ctest
-Windows users, please refer to this tutorial: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+Windows users, please refer to this tutorial: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 In the directory "application", there are three ".cpp" which instantiate IBEA, NSGAII and SPEA2 on ZDT problems. To change of algorithms, you can compare these three files and see the few changes to do.
 
 (Unix) After compilation you can run the script "DTLZ/run.sh" and see results in "IBEA.out", "NSGAII.out" and "SPEA2.out". Parameters can be modified in the script.
 
 (Windows) Add argument "IBEA.param", "SPEA2.param" or "NSGAII.param" and execute the corresponding algorithms.
-Windows users, please refer to this tutorial: http://paradiseo.gforge.inria.fr/index.php?n=Paradiseo.VisualCTutorial
+Windows users, please refer to this tutorial: https://nojhan.github.io/paradiseo/index.php?n=Paradiseo.VisualCTutorial
 
 # Documentation
 ---------------

--- a/problems/DTLZ/doc/index.h
+++ b/problems/DTLZ/doc/index.h
@@ -15,7 +15,7 @@ The installation procedure of the package is detailed in the "README.txt" file l
 @section Design
 
 For an introduction to the design of ParadisEO,
-you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+you can look at the <a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 
 @section LICENSE
@@ -44,14 +44,14 @@ you can look at the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
 
 */
 
 /** @page webpages Related webpages
 
-- ParadisEO <a href="http://paradiseo.gforge.inria.fr">homepage</a>
-- INRIA GForge <a href="http://gforge.inria.fr/projects/paradiseo/">project page</a>
-- Fore any questions, please contact paradiseo-help@lists.gforge.inria.fr
+- ParadisEO <a href="https://nojhan.github.io/paradiseo/">homepage</a>
+- GitHub <a href="https://github.com/nojhan/paradiseo">project page</a>
+- For any questions, please use the <a href="https://github.com/nojhan/paradiseo/issues">GitHub issue tracker</a>
 */

--- a/problems/DTLZ/doc/moeo.doxyfile.cmake
+++ b/problems/DTLZ/doc/moeo.doxyfile.cmake
@@ -199,7 +199,7 @@ SKIP_FUNCTION_MACROS   = YES
 #---------------------------------------------------------------------------
 # Configuration::additions related to external references   
 #---------------------------------------------------------------------------
-TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=http://eodev.sourceforge.net/eo/doc/html
+TAGFILES               = @EO_BIN_DIR@/doc/eo.doxytag=https://nojhan.github.io/paradiseo/eo/doc/html
 GENERATE_TAGFILE       = @CMAKE_BINARY_DIR@/doc/moeo.doxytag
 ALLEXTERNALS           = NO
 EXTERNAL_GROUPS        = YES

--- a/problems/DTLZ/src/DTLZ.cpp
+++ b/problems/DTLZ/src/DTLZ.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ.h
+++ b/problems/DTLZ/src/DTLZ.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ1Eval.cpp
+++ b/problems/DTLZ/src/DTLZ1Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ1Eval.h
+++ b/problems/DTLZ/src/DTLZ1Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ2Eval.cpp
+++ b/problems/DTLZ/src/DTLZ2Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ2Eval.h
+++ b/problems/DTLZ/src/DTLZ2Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ3Eval.cpp
+++ b/problems/DTLZ/src/DTLZ3Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ3Eval.h
+++ b/problems/DTLZ/src/DTLZ3Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ4Eval.cpp
+++ b/problems/DTLZ/src/DTLZ4Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ4Eval.h
+++ b/problems/DTLZ/src/DTLZ4Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ5Eval.cpp
+++ b/problems/DTLZ/src/DTLZ5Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ5Eval.h
+++ b/problems/DTLZ/src/DTLZ5Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ6Eval.cpp
+++ b/problems/DTLZ/src/DTLZ6Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ6Eval.h
+++ b/problems/DTLZ/src/DTLZ6Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ7Eval.cpp
+++ b/problems/DTLZ/src/DTLZ7Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZ7Eval.h
+++ b/problems/DTLZ/src/DTLZ7Eval.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/DTLZObjectiveVector.h
+++ b/problems/DTLZ/src/DTLZObjectiveVector.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/PolynomialMutation.h
+++ b/problems/DTLZ/src/PolynomialMutation.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/src/SBXCrossover.h
+++ b/problems/DTLZ/src/SBXCrossover.h
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ.cpp
+++ b/problems/DTLZ/test/t-DTLZ.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ1Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ1Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ2Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ2Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ3Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ3Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ4Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ4Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ5Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ5Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ6Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ6Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/DTLZ/test/t-DTLZ7Eval.cpp
+++ b/problems/DTLZ/test/t-DTLZ7Eval.cpp
@@ -30,8 +30,8 @@
 * The fact that you are presently reading this means that you have had
 * knowledge of the CeCILL license and that you accept its terms.
 *
-* ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-* Contact: paradiseo-help@lists.gforge.inria.fr
+* ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+* Contact: https://github.com/nojhan/paradiseo/issues
 *
 */
 //-----------------------------------------------------------------------------

--- a/problems/eval/bbRoyalRoadEval.h
+++ b/problems/eval/bbRoyalRoadEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _bbRoyalRoadEval_h

--- a/problems/eval/longKPathEval.h
+++ b/problems/eval/longKPathEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef __longKPathEval_h

--- a/problems/eval/maxSATeval.h
+++ b/problems/eval/maxSATeval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _maxSATeval_h

--- a/problems/eval/moPopSolEval.h
+++ b/problems/eval/moPopSolEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _moPopSolEval_h

--- a/problems/eval/nkLandscapesEval.h
+++ b/problems/eval/nkLandscapesEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef __nkLandscapesEval_H

--- a/problems/eval/nkpLandscapesEval.h
+++ b/problems/eval/nkpLandscapesEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef __nkpLandscapesEval_H

--- a/problems/eval/nkqLandscapesEval.h
+++ b/problems/eval/nkqLandscapesEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef __nkqLandscapesEval_H

--- a/problems/eval/oneMaxEval.h
+++ b/problems/eval/oneMaxEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _oneMaxEval_h

--- a/problems/eval/oneMaxPopEval.h
+++ b/problems/eval/oneMaxPopEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _oneMaxPopEval_h

--- a/problems/eval/qapEval.h
+++ b/problems/eval/qapEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _qapEval_h

--- a/problems/eval/queenEval.h
+++ b/problems/eval/queenEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _queenEval_h

--- a/problems/eval/royalRoadEval.h
+++ b/problems/eval/royalRoadEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _RoyalRoadEval_h

--- a/problems/eval/ubqpEval.h
+++ b/problems/eval/ubqpEval.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _ubqpEval_h

--- a/smp/doc/index.h
+++ b/smp/doc/index.h
@@ -8,7 +8,8 @@ Different parallelism models are available such as the Master / Slaves Model or 
 
 @section tutorials Tutorials
 
-Tutorials for ParadisEO-SMP are available in the "Tutorials section" of the <a href="http://paradiseo.gforge.inria.fr">ParadisEO website</a>.
+Tutorials for ParadisEO-SMP are available in the smp/tutorial/ directory. See also the
+<a href="https://nojhan.github.io/paradiseo/">ParadisEO website</a>.
 
 @section LICENSE
 
@@ -36,14 +37,14 @@ Tutorials for ParadisEO-SMP are available in the "Tutorials section" of the <a h
  The fact that you are presently reading this means that you have had
  knowledge of the CeCILL license and that you accept its terms.
 
- ParadisEO WebSite : http://paradiseo.gforge.inria.fr
- Contact: paradiseo-help@lists.gforge.inria.fr
+ ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+ Contact: https://github.com/nojhan/paradiseo/issues
 
 */
 
 /** @page webpages Related webpages
 
-- ParadisEO <a href="http://paradiseo.gforge.inria.fr">homepage</a>
-- INRIA GForge <a href="http://gforge.inria.fr/projects/paradiseo/">project page</a>
+- ParadisEO <a href="https://nojhan.github.io/paradiseo/">homepage</a>
+- GitHub <a href="https://github.com/nojhan/paradiseo">project page</a>
 - <a href="../../README">README</a>
 */

--- a/smp/doc/smp.doxyfile.cmake
+++ b/smp/doc/smp.doxyfile.cmake
@@ -1296,7 +1296,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen 
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               = @SMP_BIN_DIR@/doc/smp.doxytag=http://paradiseo.gforge.inria.fr/addon/smp/doc/index.html
+TAGFILES               = @SMP_BIN_DIR@/doc/smp.doxytag=https://nojhan.github.io/paradiseo/
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create 
 # a tag file that is based on the input files it reads.

--- a/smp/src/MWAlgo/MWAlgo.h
+++ b/smp/src/MWAlgo/MWAlgo.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef MWAlGO_H

--- a/smp/src/MWModel.cpp
+++ b/smp/src/MWModel.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<template <class> class EOAlgo, class EOT, class Policy>

--- a/smp/src/MWModel.h
+++ b/smp/src/MWModel.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_MWMODEL_H_

--- a/smp/src/PPExpander.h
+++ b/smp/src/PPExpander.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_PPE_H_

--- a/smp/src/abstractIsland.h
+++ b/smp/src/abstractIsland.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_ABSTRACT_ISLAND_H_

--- a/smp/src/algoDispatching.h
+++ b/smp/src/algoDispatching.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_ALGO_DISPATCHING_H_

--- a/smp/src/bimap.cpp
+++ b/smp/src/bimap.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<class A, class B>

--- a/smp/src/bimap.h
+++ b/smp/src/bimap.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_BIMAP_MODEL_H_

--- a/smp/src/contDispatching.h
+++ b/smp/src/contDispatching.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_CONT_DISPATCHING_H_

--- a/smp/src/contWrapper.cpp
+++ b/smp/src/contWrapper.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<class EOT, class bEOT>

--- a/smp/src/contWrapper.h
+++ b/smp/src/contWrapper.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_CONT_WRAPPER_H_

--- a/smp/src/intPolicy.h
+++ b/smp/src/intPolicy.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_INT_POLICY_H_

--- a/smp/src/island.cpp
+++ b/smp/src/island.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<template <class> class EOAlgo, class EOT, class bEOT>

--- a/smp/src/island.h
+++ b/smp/src/island.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_ISLAND_H_

--- a/smp/src/islandModel.cpp
+++ b/smp/src/islandModel.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <functional>

--- a/smp/src/islandModel.h
+++ b/smp/src/islandModel.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_ISLAND_MODEL_H_

--- a/smp/src/islandModelWrapper.h
+++ b/smp/src/islandModelWrapper.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_HOMOGENEOUS_ISLAND_MODEL_H_

--- a/smp/src/islandNotifier.cpp
+++ b/smp/src/islandNotifier.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template <class EOT>

--- a/smp/src/islandNotifier.h
+++ b/smp/src/islandNotifier.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_ISLAND_NOTIFIER_H_

--- a/smp/src/migPolicy.h
+++ b/smp/src/migPolicy.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_MIG_POLICY_H_

--- a/smp/src/notifier.cpp
+++ b/smp/src/notifier.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <notifier.h>

--- a/smp/src/notifier.h
+++ b/smp/src/notifier.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_NOTIFIER_H_

--- a/smp/src/policiesDispatching.h
+++ b/smp/src/policiesDispatching.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_POLICIES_DISPATCHING_H_

--- a/smp/src/policyElement.cpp
+++ b/smp/src/policyElement.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <thread>

--- a/smp/src/policyElement.h
+++ b/smp/src/policyElement.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_POLICY_ELEMENT_H_

--- a/smp/src/scheduler.cpp
+++ b/smp/src/scheduler.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<class EOT, class Policy>

--- a/smp/src/scheduler.h
+++ b/smp/src/scheduler.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_SCHEDULER_H_

--- a/smp/src/sharedFitContinue.cpp
+++ b/smp/src/sharedFitContinue.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template<class EOT>

--- a/smp/src/sharedFitContinue.h
+++ b/smp/src/sharedFitContinue.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_SHARED_FIT_CONTINUE_H_

--- a/smp/src/smp
+++ b/smp/src/smp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_INCLUDE

--- a/smp/src/smp.h
+++ b/smp/src/smp.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef SMP_H

--- a/smp/src/topology/abstractTopology.h
+++ b/smp/src/topology/abstractTopology.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef ABSTRACT_TOPO_H_

--- a/smp/src/topology/complete.cpp
+++ b/smp/src/topology/complete.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <topology/complete.h>

--- a/smp/src/topology/complete.h
+++ b/smp/src/topology/complete.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 #ifndef COMPLETE_H_
 #define COMPLETE_H_

--- a/smp/src/topology/customBooleanTopology.cpp
+++ b/smp/src/topology/customBooleanTopology.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 

--- a/smp/src/topology/customBooleanTopology.h
+++ b/smp/src/topology/customBooleanTopology.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef CUST_BOOL_TOPO_H_

--- a/smp/src/topology/customStochasticTopology.cpp
+++ b/smp/src/topology/customStochasticTopology.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 

--- a/smp/src/topology/customStochasticTopology.h
+++ b/smp/src/topology/customStochasticTopology.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef CUST_STOCH_TOPO_H_

--- a/smp/src/topology/hypercubic.cpp
+++ b/smp/src/topology/hypercubic.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 

--- a/smp/src/topology/hypercubic.h
+++ b/smp/src/topology/hypercubic.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef HYPERCUBIC_H_

--- a/smp/src/topology/mesh.cpp
+++ b/smp/src/topology/mesh.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <vector>

--- a/smp/src/topology/mesh.h
+++ b/smp/src/topology/mesh.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef MESH_H_

--- a/smp/src/topology/ring.cpp
+++ b/smp/src/topology/ring.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <vector>

--- a/smp/src/topology/ring.h
+++ b/smp/src/topology/ring.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef RING_H_

--- a/smp/src/topology/star.cpp
+++ b/smp/src/topology/star.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #include <vector>

--- a/smp/src/topology/star.h
+++ b/smp/src/topology/star.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef STAR_H_

--- a/smp/src/topology/topology.cpp
+++ b/smp/src/topology/topology.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 template <class TopologyType>	

--- a/smp/src/topology/topology.h
+++ b/smp/src/topology/topology.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef TOPOLOGY_H_

--- a/smp/src/topology/topologyBuilder.h
+++ b/smp/src/topology/topologyBuilder.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef TOPO_BUILDER_H_

--- a/smp/tutorial/Lesson1/QAP.h
+++ b/smp/tutorial/Lesson1/QAP.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef QAP_H

--- a/smp/tutorial/Lesson1/QAPGA.h
+++ b/smp/tutorial/Lesson1/QAPGA.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _QAPGA_h

--- a/smp/tutorial/Lesson1/README.md
+++ b/smp/tutorial/Lesson1/README.md
@@ -1,0 +1,23 @@
+# Master/Workers wrapping with eoEasyEA
+
+Wraps a standard eoEasyEA with the ParadisEO-SMP parallel evaluation model,
+applied to the Quadratic Assignment Problem (QAP).
+
+The QAP assigns facilities to locations to minimize cost (flow x distance).
+The representation is a permutation.
+
+## Running
+
+From the `build/smp/tutorial/Lesson1` directory:
+
+```shell
+./lesson1_eoEasyEA lesson1_eoEasyEA.param
+```
+
+## How it works
+
+The key idea: ParadisEO-SMP parallelizes evaluation by wrapping an existing
+sequential algorithm. The algorithm code itself stays the same. `QAP.h`
+defines the problem representation and evaluation, `QAPGA.h` defines the GA
+operators, and `parserStruct.h` + `utils.h` handle parameter parsing and
+instance loading. See also `lesson1_data.dat` for the problem instance.

--- a/smp/tutorial/Lesson1/lesson1_eoEasyEA.cpp
+++ b/smp/tutorial/Lesson1/lesson1_eoEasyEA.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 /**
@@ -125,5 +125,5 @@ int main(int argc, char **argv)
     delete[] b;
 
 
-    return 1;
+    return 0;
 }

--- a/smp/tutorial/Lesson1/parserStruct.h
+++ b/smp/tutorial/Lesson1/parserStruct.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 struct parameters

--- a/smp/tutorial/Lesson1/utils.h
+++ b/smp/tutorial/Lesson1/utils.h
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 #ifndef _UTILS_H

--- a/smp/tutorial/Lesson2/README.md
+++ b/smp/tutorial/Lesson2/README.md
@@ -1,0 +1,30 @@
+# Homogeneous island model
+
+Three islands running the same algorithm (`eoEasyEA`) with a complete
+topology — all islands exchange individuals with all others.
+
+Same QAP problem as Lesson 1.
+
+## Running
+
+From the `build/smp/tutorial/Lesson2` directory:
+
+```shell
+./lesson2_homogeneous
+```
+
+The problem instance is loaded from `../lessonData.dat`.
+
+## How it works
+
+All islands share the same operators (evaluation, selection, crossover,
+mutation, replacement) but can have different parameters. The topology
+and island model are set up with:
+
+```c++
+Topology<Complete> topo;
+IslandModel<Indi> model(topo);
+```
+
+Each island gets its own population and generation limit, then the model
+runs them in parallel and handles migration.

--- a/smp/tutorial/Lesson2/lesson2_homogeneous.cpp
+++ b/smp/tutorial/Lesson2/lesson2_homogeneous.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 /*///////////////////////////////////////////////////////////////////

--- a/smp/tutorial/Lesson3/README.md
+++ b/smp/tutorial/Lesson3/README.md
@@ -1,0 +1,27 @@
+# Heterogeneous island model
+
+Two islands running different algorithms: an `eoEasyEA` on the QAP problem
+and a PSO on a bitstring problem, connected via conversion functions.
+
+## Running
+
+From the `build/smp/tutorial/Lesson3` directory:
+
+```shell
+./lesson3_heterogeneous
+```
+
+## How it works
+
+When islands use different representations, you need conversion functions
+to translate individuals during migration. In this example, `fromBase()`
+and `toBase()` convert between the QAP permutation and the PSO bitstring:
+
+```c++
+Indi2 fromBase(Indi& i, unsigned size) { ... }
+Indi toBase(Indi2& i) { ... }
+```
+
+The conversions here are dummy placeholders (they just create random
+individuals), but in a real application you would implement meaningful
+mappings between representations.

--- a/smp/tutorial/Lesson3/lesson3_heterogeneous.cpp
+++ b/smp/tutorial/Lesson3/lesson3_heterogeneous.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 /*///////////////////////////////////////////////////////////////////

--- a/smp/tutorial/Lesson4/README.md
+++ b/smp/tutorial/Lesson4/README.md
@@ -1,0 +1,31 @@
+# Dynamic island topology
+
+Three islands start with a ring topology and switch to a complete topology
+after 10 seconds of computation.
+
+Same QAP problem as Lessons 1-2.
+
+## Running
+
+From the `build/smp/tutorial/Lesson4` directory:
+
+```shell
+./lesson4_topology
+```
+
+## How it works
+
+A callback function registered with the islands triggers the topology
+change:
+
+```c++
+void changeTopo(IslandModel<Indi>* _model, AbstractTopology& _topo)
+{
+    // ... after 10 seconds:
+    _model->setTopology(_topo);
+}
+```
+
+The topology can be changed at runtime via `model.setTopology()`, so you
+can implement adaptive communication patterns based on time, convergence,
+or any other criterion.

--- a/smp/tutorial/Lesson4/lesson4_topology.cpp
+++ b/smp/tutorial/Lesson4/lesson4_topology.cpp
@@ -23,8 +23,8 @@ same conditions as regards security.
 The fact that you are presently reading this means that you have had
 knowledge of the CeCILL license and that you accept its terms.
 
-ParadisEO WebSite : http://paradiseo.gforge.inria.fr
-Contact: paradiseo-help@lists.gforge.inria.fr
+ParadisEO WebSite : https://nojhan.github.io/paradiseo/
+Contact: https://github.com/nojhan/paradiseo/issues
 */
 
 /*///////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary

Fixes all broken links across the project after the migration from INRIA
GForge and SourceForge to GitHub.

- Fix factual errors in README, INSTALL, and CONTRIBUTING (cmake typo `-BUILD_TESTING` → `-DBUILD_TESTING`, wrong doc paths, outdated compiler references)
- Replace ~50 broken links in the website (`docs/index.html`) — tutorials, presentations, API docs, examples, author pages, contact info
- Fix broken links in Doxygen mainpage files for all modules (EO, MO, MOEO, SMP, DTLZ)
- Fix broken links in EO tutorial HTML and mainpage (SourceForge, personal pages, CMA-ES)
- Update ~675 license header URLs in `.h` and `.cpp` source files across all modules
- Add 9 missing tutorial READMEs for MOEO Lessons 1–4, SMP Lessons 1–4, and MO Lesson 9
- Fix `return 1` → `return 0` in 28 tutorial `main()` functions that unconditionally signaled failure

The `deprecated/` directory is intentionally left unchanged. Dead URLs inside HTML comments are preserved as historical references.

## Test plan

- [x] Grep for `gforge.inria.fr` and `eodev.sourceforge.net` outside `deprecated/` — zero hits in code/doc files
- [ ] `cmake .. && make` — verify builds succeed
- [ ] `make doc` — verify Doxygen generates without errors
- [ ] Open `docs/index.html` in browser — verify tutorial links resolve
- [ ] `ctest` — verify no test regressions