### PR TITLE
fix(eo): fix null pointer and dangling pointer bugs in eoForge

### DIFF
--- a/eo/src/eoForge.h
+++ b/eo/src/eoForge.h
@@ -203,7 +203,7 @@ class eoForgeOperator<Itf,Op> : public eoForgeInterface<Itf>
         std::shared_ptr<Itf> instantiate_ptr( bool no_cache = true ) override
         {
             if(no_cache or _instantiated == nullptr) {
-                _instantiated_ptr = std::shared_ptr<Op>();
+                _instantiated_ptr = std::make_shared<Op>();
             }
             return _instantiated_ptr;
         }
@@ -479,7 +479,7 @@ class eoForgeMap : public std::map<std::string,eoForgeInterface<Itf>*>
             delete this->at(name); // Silent on nullptr.
             auto pfo = new eoForgeOperator<Itf,Op,std::decay_t<Args>...>(
                     std::forward<Args>(args)...);
-            this->emplace({name, pfo});
+            this->at(name) = pfo;
         }
 
         /** Specialization for empty constructors.
@@ -489,7 +489,7 @@ class eoForgeMap : public std::map<std::string,eoForgeInterface<Itf>*>
         {
             delete this->at(name);
             auto pfo = new eoForgeOperator<Itf,Op>;
-            this->emplace({name, pfo});
+            this->at(name) = pfo;
         }
 
         virtual ~eoForgeMap()


### PR DESCRIPTION
## Summary

Two bugs in `eo/src/eoForge.h`:

**1. `eoForgeOperator` no-arg specialization: `instantiate_ptr()` returns null**

The partial specialization for constructors without arguments (line 206)
constructs an empty `shared_ptr` instead of allocating a new `Op`:

```cpp
// Before: default-constructs a null shared_ptr
_instantiated_ptr = std::shared_ptr<Op>();

// After: actually creates an Op instance
_instantiated_ptr = std::make_shared<Op>();
```

The full-args overload correctly uses `std::make_shared<Op>(...)` via
`op_constructor_ptr`, so this is an inconsistency in the no-arg
specialization.

**2. `eoForgeMap::setup()`: dangling pointer and memory leak**

After `delete this->at(name)`, the key remains in the map pointing to
freed memory. `std::map::emplace` does not insert when the key already
exists, so:
- The map retains the dangling pointer to the deleted object
- The newly allocated `pfo` leaks

```cpp
// Before: emplace silently no-ops on existing key
this->emplace({name, pfo});

// After: overwrites the (now-dangling) pointer with the new allocation
this->at(name) = pfo;
```

Both `setup()` overloads (with-args and no-args) had the same bug.
Note that `eoForgeVector::setup()` already does this correctly via
`this->at(index) = pfo`.

## Changes

| File | Lines |
|---|---|
| `eo/src/eoForge.h` | 3 lines changed |

## Test plan

- All 191 tests pass, including `t-operator-forge`